### PR TITLE
Fix "Parser" constant check

### DIFF
--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -24,7 +24,7 @@ module JSON
     # Set the JSON parser class _parser_ to be used by JSON.
     def parser=(parser) # :nodoc:
       @parser = parser
-      remove_const :Parser if const_defined? :Parser
+      remove_const :Parser if constants.include? :Parser
       const_set :Parser, parser
     end
 


### PR DESCRIPTION
The following line from lib/json/common.rb checks whether 'Parser' is defined within the module JSON before trying to remove it:

  remove_const :Parser if const_defined? :Parser

However, if the user already has an existing constant 'Parser' defined (outside the module JSON), then 'const_defined? :Parser' will return true regardless of whether JSON::Parser exists. Thus, 'remove_const' will always be called and Ruby will throw an error. This can be fixed by instead using:

  remove_const :Parser if constants.include? :Parser

Thanks,
Riley
