### PR TITLE
flori/json#61: JRuby gem doesn't build

### DIFF
--- a/json-java.gemspec
+++ b/json-java.gemspec
@@ -15,6 +15,3 @@ spec = Gem::Specification.new do |s|
   s.files = Dir["{docs,lib,tests}/**/*"]
 end
 
-if $0 == __FILE__
-  Gem::Builder.new(spec).build
-end


### PR DESCRIPTION
This change fixes the issue described in flori/json#61.

Tested with JRuby 1.5.6 and 1.6.0.RC2.
