### PR TITLE
has_rdoc= and default_executable= have been deprecated

### DIFF
--- a/json.gemspec
+++ b/json.gemspec
@@ -16,9 +16,7 @@ Gem::Specification.new do |s|
 
   s.bindir = "bin"
   s.executables = [ "edit_json.rb", "prettify_json.rb" ]
-  s.default_executable = "edit_json.rb"
 
-  s.has_rdoc = true
   s.extra_rdoc_files << 'README'
   s.rdoc_options <<
     '--title' <<  'JSON implemention for Ruby' << '--main' << 'README'

--- a/json_pure.gemspec
+++ b/json_pure.gemspec
@@ -12,9 +12,7 @@ Gem::Specification.new do |s|
 
   s.bindir = "bin"
   s.executables = [ "edit_json.rb", "prettify_json.rb" ]
-  s.default_executable = "edit_json.rb"
 
-  s.has_rdoc = true
   s.extra_rdoc_files << 'README'
   s.rdoc_options <<
     '--title' <<  'JSON implemention for ruby' << '--main' << 'README'


### PR DESCRIPTION
`Gem::Specification#has_rdoc=` and `Gem::Specification#default_executable=` have been deprecated (see http://blog.segment7.net/2011/04/01/rubygems-1-7-0 for example). So it's better to remove them to avoid future breakage.
