### PR TITLE
Fix memory leak when used from multiple JRuby runtimes.

### DIFF
--- a/java/src/json/ext/Generator.java
+++ b/java/src/json/ext/Generator.java
@@ -376,9 +376,9 @@ public final class Generator {
                 RubyString src;
 
                 if (info.encodingsSupported() &&
-                        object.encoding(session.getContext()) != info.utf8) {
+                        object.encoding(session.getContext()) != info.utf8.get()) {
                     src = (RubyString)object.encode(session.getContext(),
-                                                    info.utf8);
+                                                    info.utf8.get());
                 } else {
                     src = object;
                 }

--- a/java/src/json/ext/GeneratorMethods.java
+++ b/java/src/json/ext/GeneratorMethods.java
@@ -6,6 +6,7 @@
  */
 package json.ext;
 
+import java.lang.ref.WeakReference;
 import org.jruby.Ruby;
 import org.jruby.RubyArray;
 import org.jruby.RubyBoolean;
@@ -45,9 +46,9 @@ class GeneratorMethods {
         defineMethods(module, "String",     RbString.class);
         defineMethods(module, "TrueClass",  RbTrue.class);
 
-        info.stringExtendModule = module.defineModuleUnder("String")
-                                            .defineModuleUnder("Extend");
-        info.stringExtendModule.defineAnnotatedMethods(StringExtend.class);
+        info.stringExtendModule = new WeakReference<RubyModule>(module.defineModuleUnder("String")
+                                            .defineModuleUnder("Extend"));
+        info.stringExtendModule.get().defineAnnotatedMethods(StringExtend.class);
     }
 
     /**
@@ -140,7 +141,7 @@ class GeneratorMethods {
             RubyHash result = RubyHash.newHash(runtime);
 
             IRubyObject createId = RuntimeInfo.forRuntime(runtime)
-                    .jsonModule.callMethod(context, "create_id");
+                    .jsonModule.get().callMethod(context, "create_id");
             result.op_aset(context, createId, self.getMetaClass().to_s());
 
             ByteList bl = self.getByteList();
@@ -158,7 +159,7 @@ class GeneratorMethods {
         public static IRubyObject included(ThreadContext context,
                 IRubyObject vSelf, IRubyObject module) {
             RuntimeInfo info = RuntimeInfo.forRuntime(context.getRuntime());
-            return module.callMethod(context, "extend", info.stringExtendModule);
+            return module.callMethod(context, "extend", info.stringExtendModule.get());
         }
     }
 

--- a/java/src/json/ext/GeneratorService.java
+++ b/java/src/json/ext/GeneratorService.java
@@ -7,6 +7,7 @@
 package json.ext;
 
 import java.io.IOException;
+import java.lang.ref.WeakReference;
 
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
@@ -23,15 +24,15 @@ public class GeneratorService implements BasicLibraryService {
         runtime.getLoadService().require("json/common");
         RuntimeInfo info = RuntimeInfo.initRuntime(runtime);
 
-        info.jsonModule = runtime.defineModule("JSON");
-        RubyModule jsonExtModule = info.jsonModule.defineModuleUnder("Ext");
+        info.jsonModule = new WeakReference<RubyModule>(runtime.defineModule("JSON"));
+        RubyModule jsonExtModule = info.jsonModule.get().defineModuleUnder("Ext");
         RubyModule generatorModule = jsonExtModule.defineModuleUnder("Generator");
 
         RubyClass stateClass =
             generatorModule.defineClassUnder("State", runtime.getObject(),
                                              GeneratorState.ALLOCATOR);
         stateClass.defineAnnotatedMethods(GeneratorState.class);
-        info.generatorStateClass = stateClass;
+        info.generatorStateClass = new WeakReference<RubyClass>(stateClass);
 
         RubyModule generatorMethods =
             generatorModule.defineModuleUnder("GeneratorMethods");

--- a/java/src/json/ext/GeneratorState.java
+++ b/java/src/json/ext/GeneratorState.java
@@ -118,7 +118,7 @@ public class GeneratorState extends RubyObject {
 
     static GeneratorState fromState(ThreadContext context, RuntimeInfo info,
                                     IRubyObject opts) {
-        RubyClass klass = info.generatorStateClass;
+        RubyClass klass = info.generatorStateClass.get();
         if (opts != null) {
             // if the given parameter is a Generator::State, return itself
             if (klass.isInstance(opts)) return (GeneratorState)opts;
@@ -382,8 +382,8 @@ public class GeneratorState extends RubyObject {
     private ByteList prepareByteList(ThreadContext context, IRubyObject value) {
         RubyString str = value.convertToString();
         RuntimeInfo info = RuntimeInfo.forRuntime(context.getRuntime());
-        if (info.encodingsSupported() && str.encoding(context) != info.utf8) {
-            str = (RubyString)str.encode(context, info.utf8);
+        if (info.encodingsSupported() && str.encoding(context) != info.utf8.get()) {
+            str = (RubyString)str.encode(context, info.utf8.get());
         }
         return str.getByteList().dup();
     }

--- a/java/src/json/ext/OptionsReader.java
+++ b/java/src/json/ext/OptionsReader.java
@@ -84,8 +84,8 @@ final class OptionsReader {
 
         RubyString str = value.convertToString();
         RuntimeInfo info = getRuntimeInfo();
-        if (info.encodingsSupported() && str.encoding(context) != info.utf8) {
-            str = (RubyString)str.encode(context, info.utf8);
+        if (info.encodingsSupported() && str.encoding(context) != info.utf8.get()) {
+            str = (RubyString)str.encode(context, info.utf8.get());
         }
         return str;
     }

--- a/java/src/json/ext/Parser.java
+++ b/java/src/json/ext/Parser.java
@@ -176,8 +176,8 @@ public class Parser extends RubyObject {
 
         if (info.encodingsSupported()) {
             RubyEncoding encoding = (RubyEncoding)source.encoding(context);
-            if (encoding != info.ascii8bit) {
-                return (RubyString)source.encode(context, info.utf8);
+            if (encoding != info.ascii8bit.get()) {
+                return (RubyString)source.encode(context, info.utf8.get());
             }
 
             String sniffedEncoding = sniffByteList(bl);
@@ -188,7 +188,7 @@ public class Parser extends RubyObject {
         String sniffedEncoding = sniffByteList(bl);
         if (sniffedEncoding == null) return source; // assume UTF-8
         Ruby runtime = context.getRuntime();
-        return (RubyString)info.jsonModule.
+        return (RubyString)info.jsonModule.get().
             callMethod(context, "iconv",
                 new IRubyObject[] {
                     runtime.newString("utf-8"),
@@ -218,7 +218,7 @@ public class Parser extends RubyObject {
     private RubyString reinterpretEncoding(ThreadContext context,
             RubyString str, String sniffedEncoding) {
         RubyEncoding actualEncoding = info.getEncoding(context, sniffedEncoding);
-        RubyEncoding targetEncoding = info.utf8;
+        RubyEncoding targetEncoding = info.utf8.get();
         RubyString dup = (RubyString)str.dup();
         dup.force_encoding(context, actualEncoding);
         return (RubyString)dup.encode_bang(context, targetEncoding);
@@ -251,7 +251,7 @@ public class Parser extends RubyObject {
      * set to <code>nil</code> or <code>false</code>, and a String if not.
      */
     private RubyString getCreateId(ThreadContext context) {
-        IRubyObject v = info.jsonModule.callMethod(context, "create_id");
+        IRubyObject v = info.jsonModule.get().callMethod(context, "create_id");
         return v.isTrue() ? v.convertToString() : null;
     }
 
@@ -1985,7 +1985,7 @@ case 5:
                 IRubyObject vKlassName = result.op_aref(context, parser.createId);
                 if (!vKlassName.isNil()) {
                     // might throw ArgumentError, we let it propagate
-                    IRubyObject klass = parser.info.jsonModule.
+                    IRubyObject klass = parser.info.jsonModule.get().
                             callMethod(context, "deep_const_get", vKlassName);
                     if (klass.respondsTo("json_creatable?") &&
                         klass.callMethod(context, "json_creatable?").isTrue()) {
@@ -2275,7 +2275,7 @@ case 5:
          * @param name The constant name
          */
         private IRubyObject getConstant(String name) {
-            return parser.info.jsonModule.getConstant(name);
+            return parser.info.jsonModule.get().getConstant(name);
         }
 
         private RaiseException newException(String className, String message) {

--- a/java/src/json/ext/ParserService.java
+++ b/java/src/json/ext/ParserService.java
@@ -7,6 +7,7 @@
 package json.ext;
 
 import java.io.IOException;
+import java.lang.ref.WeakReference;
 
 import org.jruby.Ruby;
 import org.jruby.RubyClass;
@@ -23,8 +24,8 @@ public class ParserService implements BasicLibraryService {
         runtime.getLoadService().require("json/common");
         RuntimeInfo info = RuntimeInfo.initRuntime(runtime);
 
-        info.jsonModule = runtime.defineModule("JSON");
-        RubyModule jsonExtModule = info.jsonModule.defineModuleUnder("Ext");
+        info.jsonModule = new WeakReference<RubyModule>(runtime.defineModule("JSON"));
+        RubyModule jsonExtModule = info.jsonModule.get().defineModuleUnder("Ext");
         RubyClass parserClass =
             jsonExtModule.defineClassUnder("Parser", runtime.getObject(),
                                            Parser.ALLOCATOR);

--- a/java/src/json/ext/Utils.java
+++ b/java/src/json/ext/Utils.java
@@ -66,7 +66,7 @@ final class Utils {
     static RaiseException newException(ThreadContext context,
                                        String className, RubyString message) {
         RuntimeInfo info = RuntimeInfo.forRuntime(context.getRuntime());
-        RubyClass klazz = info.jsonModule.getClass(className);
+        RubyClass klazz = info.jsonModule.get().getClass(className);
         RubyException excptn =
             (RubyException)klazz.newInstance(context,
                 new IRubyObject[] {message}, Block.NULL_BLOCK);


### PR DESCRIPTION
If json/ext/parser is required from multiple JRuby runtimes in the same JVM, it will leak memory for every runtime beyond the first.

Test script: https://gist.github.com/971319

The leak is caused by taking references to the runtimes in the RuntimeInfo class, particularly the WeakHashMap<Ruby, RuntimeInfo>. Note the caveat in the WeakHashMap JavaDocs:

Implementation note: The value objects in a WeakHashMap are held by ordinary strong references. Thus care should be taken to ensure that value objects do not strongly refer to their own keys, either directly or indirectly, since that will prevent the keys from being discarded. Note that a value object may refer indirectly to its key via the WeakHashMap itself; that is, a value object may strongly refer to some other key object whose associated value object, in turn, strongly refers to the key of the first value object. One way to deal with this is to wrap values themselves within WeakReferences before inserting, as in: m.put(key, new WeakReference(value)), and then unwrapping upon each get.

This applies here, because each RuntimeInfo has internal references to the corresponding Ruby object via the members jsonModule, stringExtendModule, etc -- these will all contain internal references to the runtime.

Using WeakReference<RuntimeInfo> as the value object instead fixes the leak as shown by the test script.

Note: also reported [here](https://github.com/mernen/json-jruby/issues/7). It looks like active development for all platforms is going on in this repository now, so I submitted the pull request here. Let me know if this is not the desired workflow.
