### PR TITLE
Don't load complex and rational on 1.9.

### DIFF
--- a/lib/json/add/core.rb
+++ b/lib/json/add/core.rb
@@ -5,8 +5,8 @@ unless defined?(::JSON::JSON_LOADED) and ::JSON::JSON_LOADED
   require 'json'
 end
 require 'date'
-require 'complex'
-require 'rational'
+require 'complex' unless defined?(Complex)
+require 'rational' unless defined?(Rational)
 
 # Symbol serialization/deserialization
 class Symbol


### PR DESCRIPTION
On 1.9 Complex and Rational are builtined.
On the other hand complex and rational library enables compatible layer,
it changes the behavior of builtin Complex and Rational; it is harmful.
So require them only when they are not defined.
