### PR TITLE
HAVE_RUBY_RE_H and HAVE_RUBY_RE_H are defined in ruby.h by default.

### DIFF
--- a/ext/json/ext/generator/extconf.rb
+++ b/ext/json/ext/generator/extconf.rb
@@ -1,5 +1,4 @@
 require 'mkmf'
-require 'rbconfig'
 
 unless $CFLAGS.gsub!(/ -O[\dsz]?/, ' -O3')
   $CFLAGS << ' -O3'
@@ -11,10 +10,4 @@ if CONFIG['CC'] =~ /gcc/
   #end
 end
 
-if RUBY_VERSION < "1.9"
-  have_header("re.h")
-else
-  have_header("ruby/re.h")
-  have_header("ruby/encoding.h")
-end
 create_makefile 'json/ext/generator'

--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -7,11 +7,9 @@
 
 #include "ruby.h"
 
-#if HAVE_RUBY_RE_H
+#ifdef HAVE_RUBY_RE_H
 #include "ruby/re.h"
-#endif
-
-#if HAVE_RE_H
+#else
 #include "re.h"
 #endif
 

--- a/ext/json/ext/parser/extconf.rb
+++ b/ext/json/ext/parser/extconf.rb
@@ -1,5 +1,4 @@
 require 'mkmf'
-require 'rbconfig'
 
 unless $CFLAGS.gsub!(/ -O[\dsz]?/, ' -O3')
   $CFLAGS << ' -O3'
@@ -11,6 +10,4 @@ if CONFIG['CC'] =~ /gcc/
   #end
 end
 
-have_header("re.h")
-have_header("ruby/st.h")
 create_makefile 'json/ext/parser'

--- a/ext/json/ext/parser/parser.h
+++ b/ext/json/ext/parser/parser.h
@@ -3,7 +3,7 @@
 
 #include "ruby.h"
 
-#if HAVE_RE_H
+#ifndef HAVE_RUBY_RE_H
 #include "re.h"
 #endif
 


### PR DESCRIPTION
So you don't need to check them in extconf.rb.
