### PR TITLE
Adding to_json support for BigDecimal. 

### DIFF
--- a/lib/json/add/big_decimal.rb
+++ b/lib/json/add/big_decimal.rb
@@ -1,0 +1,13 @@
+unless defined?(::JSON::JSON_LOADED) and ::JSON::JSON_LOADED
+  require 'json'
+end
+require 'bigdecimal' unless defined? BigDecimal
+
+class BigDecimal
+
+  def to_json
+    to_i
+  end
+
+end
+

--- a/lib/json/add/core.rb
+++ b/lib/json/add/core.rb
@@ -1,6 +1,7 @@
 # This file requires the implementations of ruby core's custom objects for
 # serialisation/deserialisation.
 
+require 'json/add/big_decimal'
 require 'json/add/date'
 require 'json/add/date_time'
 require 'json/add/exception'

--- a/tests/test_json_add_big_decimal.rb
+++ b/tests/test_json_add_big_decimal.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# -*- coding:utf-8 -*-
+
+require 'test/unit'
+require File.join(File.dirname(__FILE__), 'setup_variant')
+require 'json/add/big_decimal'
+
+class TC_JSONAddBigDecimal < Test::Unit::TestCase
+
+  def test_to_json
+    assert_equal 2, BigDecimal.new('2').to_json
+  end
+
+end
+


### PR DESCRIPTION
This commit adds to_json support for BigDecimal. I encountered BigDecimal when using Oracle column datatype of NUMBER.
