### PR TITLE
Fix for Time.json_create in Ruby 1.9.2

### DIFF
--- a/lib/json/add/time.rb
+++ b/lib/json/add/time.rb
@@ -10,8 +10,8 @@ class Time
     if usec = object.delete('u') # used to be tv_usec -> tv_nsec
       object['n'] = usec * 1000
     end
-    if respond_to?(:tv_nsec)
-      at(*object.values_at('s', 'n'))
+    if instance_methods.include?(:tv_nsec)
+      at(object['s'], Rational(object['n'], 1000))
     else
       at(object['s'], object['n'] / 1000)
     end

--- a/tests/test_json_addition.rb
+++ b/tests/test_json_addition.rb
@@ -129,7 +129,7 @@ class TC_JSONAddition < Test::Unit::TestCase
 
   def test_core
     t = Time.now
-    assert_equal t.inspect, JSON(JSON(t)).inspect
+    assert_equal t, JSON(JSON(t))
     d = Date.today
     assert_equal d, JSON(JSON(d))
     d = DateTime.civil(2007, 6, 14, 14, 57, 10, Rational(1, 12), 2299161)


### PR DESCRIPTION
Hi,

Working with the JSON 1.6.1 lib in Ruby 1.9.2 (MRI), I'm finding that Time instances don't round trip properly, so:

```
jpartlow@halbarad:~/dev/json$ irb -I lib
ruby-1.9.2-p290 :001 > require 'json'
 => true 
ruby-1.9.2-p290 :002 > require 'json/add/time'
 => true 
ruby-1.9.2-p290 :003 > t = Time.now
 => 2011-11-18 22:01:37 -0800 
ruby-1.9.2-p290 :004 > t2 = JSON(JSON(t))
 => 2011-11-18 22:15:46 -0800 
ruby-1.9.2-p290 :005 > t == t2
 => false 
ruby-1.9.2-p290 :006 > t.nsec
 => 513434780 
ruby-1.9.2-p290 :007 > t2.nsec
 => 513434000 
ruby-1.9.2-p290 :005 > Marshal.load(Marshal.dump(t)) == t
 => true 
```

It looks like Time.json_create has two issues, one it was checking for the existence of #tv_sec in Time rather than a Time instance, and so was never running the variant meant for the newer Time class with nsec attribute.  Also, I think the newer Time.at requires (sec, usec) where usec can be fractional to represent nanosecs.

The test suite was masking this by checking t.inspect rather than t for the equality test.

I've only tested this on 1.9.2, so I might be overlooking something that is important for another Ruby version.

thanks,
Josh

  ruby:
    interpreter:  "ruby"
    version:      "1.9.2p290"
    date:         "2011-07-09"
    platform:     "x86_64-linux"
    patchlevel:   "2011-07-09 revision 32553"
    full_version: "ruby 1.9.2p290 (2011-07-09 revision 32553) [x86_64-linux]"
