### PR TITLE
Only allocate a single "view" bytelist, and update it as needed.

### DIFF
--- a/java/src/json/ext/Parser.java
+++ b/java/src/json/ext/Parser.java
@@ -305,6 +305,7 @@ public class Parser extends RubyObject {
         private final Parser parser;
         private final ThreadContext context;
         private final ByteList byteList;
+        private final ByteList view;
         private final byte[] data;
         private final StringDecoder decoder;
         private int currentNesting = 0;
@@ -319,6 +320,7 @@ public class Parser extends RubyObject {
             this.context = context;
             this.byteList = parser.checkAndGetSource().getByteList();
             this.data = byteList.unsafeBytes();
+            this.view = new ByteList(data, false);
             this.decoder = new StringDecoder(context);
             this.dc = new DoubleConverter();
         }
@@ -335,11 +337,11 @@ public class Parser extends RubyObject {
         }
 
         
-// line 361 "Parser.rl"
+// line 363 "Parser.rl"
 
 
         
-// line 343 "Parser.java"
+// line 345 "Parser.java"
 private static byte[] init__JSON_value_actions_0()
 {
 	return new byte [] {
@@ -453,7 +455,7 @@ static final int JSON_value_error = 0;
 static final int JSON_value_en_main = 1;
 
 
-// line 467 "Parser.rl"
+// line 469 "Parser.rl"
 
 
         void parseValue(ParserResult res, int p, int pe) {
@@ -461,14 +463,14 @@ static final int JSON_value_en_main = 1;
             IRubyObject result = null;
 
             
-// line 465 "Parser.java"
+// line 467 "Parser.java"
 	{
 	cs = JSON_value_start;
 	}
 
-// line 474 "Parser.rl"
+// line 476 "Parser.rl"
             
-// line 472 "Parser.java"
+// line 474 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -494,13 +496,13 @@ case 1:
 	while ( _nacts-- > 0 ) {
 		switch ( _JSON_value_actions[_acts++] ) {
 	case 9:
-// line 452 "Parser.rl"
+// line 454 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 504 "Parser.java"
+// line 506 "Parser.java"
 		}
 	}
 
@@ -563,25 +565,25 @@ case 1:
 			switch ( _JSON_value_actions[_acts++] )
 			{
 	case 0:
-// line 369 "Parser.rl"
+// line 371 "Parser.rl"
 	{
                 result = getRuntime().getNil();
             }
 	break;
 	case 1:
-// line 372 "Parser.rl"
+// line 374 "Parser.rl"
 	{
                 result = getRuntime().getFalse();
             }
 	break;
 	case 2:
-// line 375 "Parser.rl"
+// line 377 "Parser.rl"
 	{
                 result = getRuntime().getTrue();
             }
 	break;
 	case 3:
-// line 378 "Parser.rl"
+// line 380 "Parser.rl"
 	{
                 if (parser.allowNaN) {
                     result = getConstant(CONST_NAN);
@@ -591,7 +593,7 @@ case 1:
             }
 	break;
 	case 4:
-// line 385 "Parser.rl"
+// line 387 "Parser.rl"
 	{
                 if (parser.allowNaN) {
                     result = getConstant(CONST_INFINITY);
@@ -601,7 +603,7 @@ case 1:
             }
 	break;
 	case 5:
-// line 392 "Parser.rl"
+// line 394 "Parser.rl"
 	{
                 if (pe > p + 9 - (parser.quirksMode ? 1 : 0) &&
                     absSubSequence(p, p + 9).equals(JSON_MINUS_INFINITY)) {
@@ -630,7 +632,7 @@ case 1:
             }
 	break;
 	case 6:
-// line 418 "Parser.rl"
+// line 420 "Parser.rl"
 	{
                 parseString(res, p, pe);
                 if (res.result == null) {
@@ -643,7 +645,7 @@ case 1:
             }
 	break;
 	case 7:
-// line 428 "Parser.rl"
+// line 430 "Parser.rl"
 	{
                 currentNesting++;
                 parseArray(res, p, pe);
@@ -658,7 +660,7 @@ case 1:
             }
 	break;
 	case 8:
-// line 440 "Parser.rl"
+// line 442 "Parser.rl"
 	{
                 currentNesting++;
                 parseObject(res, p, pe);
@@ -672,7 +674,7 @@ case 1:
                 }
             }
 	break;
-// line 676 "Parser.java"
+// line 678 "Parser.java"
 			}
 		}
 	}
@@ -692,7 +694,7 @@ case 5:
 	break; }
 	}
 
-// line 475 "Parser.rl"
+// line 477 "Parser.rl"
 
             if (cs >= JSON_value_first_final && result != null) {
                 res.update(result, p);
@@ -702,7 +704,7 @@ case 5:
         }
 
         
-// line 706 "Parser.java"
+// line 708 "Parser.java"
 private static byte[] init__JSON_integer_actions_0()
 {
 	return new byte [] {
@@ -801,7 +803,7 @@ static final int JSON_integer_error = 0;
 static final int JSON_integer_en_main = 1;
 
 
-// line 494 "Parser.rl"
+// line 496 "Parser.rl"
 
 
         void parseInteger(ParserResult res, int p, int pe) {
@@ -819,15 +821,15 @@ static final int JSON_integer_en_main = 1;
             int cs = EVIL;
 
             
-// line 823 "Parser.java"
+// line 825 "Parser.java"
 	{
 	cs = JSON_integer_start;
 	}
 
-// line 511 "Parser.rl"
+// line 513 "Parser.rl"
             int memo = p;
             
-// line 831 "Parser.java"
+// line 833 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -908,13 +910,13 @@ case 1:
 			switch ( _JSON_integer_actions[_acts++] )
 			{
 	case 0:
-// line 488 "Parser.rl"
+// line 490 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 918 "Parser.java"
+// line 920 "Parser.java"
 			}
 		}
 	}
@@ -934,7 +936,7 @@ case 5:
 	break; }
 	}
 
-// line 513 "Parser.rl"
+// line 515 "Parser.rl"
 
             if (cs < JSON_integer_first_final) {
                 return -1;
@@ -956,7 +958,7 @@ case 5:
         }
 
         
-// line 960 "Parser.java"
+// line 962 "Parser.java"
 private static byte[] init__JSON_float_actions_0()
 {
 	return new byte [] {
@@ -1058,7 +1060,7 @@ static final int JSON_float_error = 0;
 static final int JSON_float_en_main = 1;
 
 
-// line 548 "Parser.rl"
+// line 550 "Parser.rl"
 
 
         void parseFloat(ParserResult res, int p, int pe) {
@@ -1076,15 +1078,15 @@ static final int JSON_float_en_main = 1;
             int cs = EVIL;
 
             
-// line 1080 "Parser.java"
+// line 1082 "Parser.java"
 	{
 	cs = JSON_float_start;
 	}
 
-// line 565 "Parser.rl"
+// line 567 "Parser.rl"
             int memo = p;
             
-// line 1088 "Parser.java"
+// line 1090 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1165,13 +1167,13 @@ case 1:
 			switch ( _JSON_float_actions[_acts++] )
 			{
 	case 0:
-// line 539 "Parser.rl"
+// line 541 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1175 "Parser.java"
+// line 1177 "Parser.java"
 			}
 		}
 	}
@@ -1191,7 +1193,7 @@ case 5:
 	break; }
 	}
 
-// line 567 "Parser.rl"
+// line 569 "Parser.rl"
 
             if (cs < JSON_float_first_final) {
                 return -1;
@@ -1207,7 +1209,7 @@ case 5:
         }
 
         
-// line 1211 "Parser.java"
+// line 1213 "Parser.java"
 private static byte[] init__JSON_string_actions_0()
 {
 	return new byte [] {
@@ -1309,7 +1311,7 @@ static final int JSON_string_error = 0;
 static final int JSON_string_en_main = 1;
 
 
-// line 612 "Parser.rl"
+// line 614 "Parser.rl"
 
 
         void parseString(ParserResult res, int p, int pe) {
@@ -1317,15 +1319,15 @@ static final int JSON_string_en_main = 1;
             IRubyObject result = null;
 
             
-// line 1321 "Parser.java"
+// line 1323 "Parser.java"
 	{
 	cs = JSON_string_start;
 	}
 
-// line 619 "Parser.rl"
+// line 621 "Parser.rl"
             int memo = p;
             
-// line 1329 "Parser.java"
+// line 1331 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1406,7 +1408,7 @@ case 1:
 			switch ( _JSON_string_actions[_acts++] )
 			{
 	case 0:
-// line 587 "Parser.rl"
+// line 589 "Parser.rl"
 	{
                 int offset = byteList.begin();
                 ByteList decoded = decoder.decode(byteList, memo + 1 - offset,
@@ -1421,13 +1423,13 @@ case 1:
             }
 	break;
 	case 1:
-// line 600 "Parser.rl"
+// line 602 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1431 "Parser.java"
+// line 1433 "Parser.java"
 			}
 		}
 	}
@@ -1447,7 +1449,7 @@ case 5:
 	break; }
 	}
 
-// line 621 "Parser.rl"
+// line 623 "Parser.rl"
 
             if (parser.createAdditions) {
                 RubyHash match_string = parser.match_string;
@@ -1482,7 +1484,7 @@ case 5:
         }
 
         
-// line 1486 "Parser.java"
+// line 1488 "Parser.java"
 private static byte[] init__JSON_array_actions_0()
 {
 	return new byte [] {
@@ -1595,7 +1597,7 @@ static final int JSON_array_error = 0;
 static final int JSON_array_en_main = 1;
 
 
-// line 691 "Parser.rl"
+// line 693 "Parser.rl"
 
 
         void parseArray(ParserResult res, int p, int pe) {
@@ -1617,14 +1619,14 @@ static final int JSON_array_en_main = 1;
             }
 
             
-// line 1621 "Parser.java"
+// line 1623 "Parser.java"
 	{
 	cs = JSON_array_start;
 	}
 
-// line 712 "Parser.rl"
+// line 714 "Parser.rl"
             
-// line 1628 "Parser.java"
+// line 1630 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1705,7 +1707,7 @@ case 1:
 			switch ( _JSON_array_actions[_acts++] )
 			{
 	case 0:
-// line 660 "Parser.rl"
+// line 662 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -1722,13 +1724,13 @@ case 1:
             }
 	break;
 	case 1:
-// line 675 "Parser.rl"
+// line 677 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1732 "Parser.java"
+// line 1734 "Parser.java"
 			}
 		}
 	}
@@ -1748,7 +1750,7 @@ case 5:
 	break; }
 	}
 
-// line 713 "Parser.rl"
+// line 715 "Parser.rl"
 
             if (cs >= JSON_array_first_final) {
                 res.update(result, p + 1);
@@ -1758,7 +1760,7 @@ case 5:
         }
 
         
-// line 1762 "Parser.java"
+// line 1764 "Parser.java"
 private static byte[] init__JSON_object_actions_0()
 {
 	return new byte [] {
@@ -1881,7 +1883,7 @@ static final int JSON_object_error = 0;
 static final int JSON_object_en_main = 1;
 
 
-// line 772 "Parser.rl"
+// line 774 "Parser.rl"
 
 
         void parseObject(ParserResult res, int p, int pe) {
@@ -1906,14 +1908,14 @@ static final int JSON_object_en_main = 1;
             }
 
             
-// line 1910 "Parser.java"
+// line 1912 "Parser.java"
 	{
 	cs = JSON_object_start;
 	}
 
-// line 796 "Parser.rl"
+// line 798 "Parser.rl"
             
-// line 1917 "Parser.java"
+// line 1919 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1994,7 +1996,7 @@ case 1:
 			switch ( _JSON_object_actions[_acts++] )
 			{
 	case 0:
-// line 727 "Parser.rl"
+// line 729 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -2011,7 +2013,7 @@ case 1:
             }
 	break;
 	case 1:
-// line 742 "Parser.rl"
+// line 744 "Parser.rl"
 	{
                 parseString(res, p, pe);
                 if (res.result == null) {
@@ -2031,13 +2033,13 @@ case 1:
             }
 	break;
 	case 2:
-// line 760 "Parser.rl"
+// line 762 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 2041 "Parser.java"
+// line 2043 "Parser.java"
 			}
 		}
 	}
@@ -2057,9 +2059,10 @@ case 5:
 	break; }
 	}
 
-// line 797 "Parser.rl"
+// line 799 "Parser.rl"
 
             if (cs < JSON_object_first_final) {
+                res.update(null, p + 1);
                 return;
             }
 
@@ -2089,7 +2092,7 @@ case 5:
         }
 
         
-// line 2093 "Parser.java"
+// line 2096 "Parser.java"
 private static byte[] init__JSON_actions_0()
 {
 	return new byte [] {
@@ -2193,7 +2196,7 @@ static final int JSON_error = 0;
 static final int JSON_en_main = 1;
 
 
-// line 861 "Parser.rl"
+// line 864 "Parser.rl"
 
 
         public IRubyObject parseStrict() {
@@ -2203,16 +2206,16 @@ static final int JSON_en_main = 1;
             ParserResult res = new ParserResult();
 
             
-// line 2207 "Parser.java"
+// line 2210 "Parser.java"
 	{
 	cs = JSON_start;
 	}
 
-// line 870 "Parser.rl"
+// line 873 "Parser.rl"
             p = byteList.begin();
             pe = p + byteList.length();
             
-// line 2216 "Parser.java"
+// line 2219 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -2293,7 +2296,7 @@ case 1:
 			switch ( _JSON_actions[_acts++] )
 			{
 	case 0:
-// line 833 "Parser.rl"
+// line 836 "Parser.rl"
 	{
                 currentNesting = 1;
                 parseObject(res, p, pe);
@@ -2307,7 +2310,7 @@ case 1:
             }
 	break;
 	case 1:
-// line 845 "Parser.rl"
+// line 848 "Parser.rl"
 	{
                 currentNesting = 1;
                 parseArray(res, p, pe);
@@ -2320,7 +2323,7 @@ case 1:
                 }
             }
 	break;
-// line 2324 "Parser.java"
+// line 2327 "Parser.java"
 			}
 		}
 	}
@@ -2340,7 +2343,7 @@ case 5:
 	break; }
 	}
 
-// line 873 "Parser.rl"
+// line 876 "Parser.rl"
 
             if (cs >= JSON_first_final && p == pe) {
                 return result;
@@ -2350,7 +2353,7 @@ case 5:
         }
 
         
-// line 2354 "Parser.java"
+// line 2357 "Parser.java"
 private static byte[] init__JSON_quirks_mode_actions_0()
 {
 	return new byte [] {
@@ -2453,7 +2456,7 @@ static final int JSON_quirks_mode_error = 0;
 static final int JSON_quirks_mode_en_main = 1;
 
 
-// line 901 "Parser.rl"
+// line 904 "Parser.rl"
 
 
         public IRubyObject parseQuirksMode() {
@@ -2463,16 +2466,16 @@ static final int JSON_quirks_mode_en_main = 1;
             ParserResult res = new ParserResult();
 
             
-// line 2467 "Parser.java"
+// line 2470 "Parser.java"
 	{
 	cs = JSON_quirks_mode_start;
 	}
 
-// line 910 "Parser.rl"
+// line 913 "Parser.rl"
             p = byteList.begin();
             pe = p + byteList.length();
             
-// line 2476 "Parser.java"
+// line 2479 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -2553,7 +2556,7 @@ case 1:
 			switch ( _JSON_quirks_mode_actions[_acts++] )
 			{
 	case 0:
-// line 887 "Parser.rl"
+// line 890 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -2565,7 +2568,7 @@ case 1:
                 }
             }
 	break;
-// line 2569 "Parser.java"
+// line 2572 "Parser.java"
 			}
 		}
 	}
@@ -2585,7 +2588,7 @@ case 5:
 	break; }
 	}
 
-// line 913 "Parser.rl"
+// line 916 "Parser.rl"
 
             if (cs >= JSON_quirks_mode_first_final && p == pe) {
                 return result;
@@ -2604,14 +2607,14 @@ case 5:
         }
 
         /**
-         * Returns a subsequence of the source ByteList, based on source
-         * array byte offsets (i.e., the ByteList's own begin offset is not
-         * automatically added).
+         * Updates the "view" bytelist with the new offsets and returns it.
          * @param start
          * @param end
          */
         private ByteList absSubSequence(int absStart, int absEnd) {
-            return new ByteList(byteList.unsafeBytes(), absStart, absEnd - absStart, false);
+            view.setBegin(absStart);
+            view.setRealSize(absEnd - absStart);
+            return view;
         }
 
         /**

--- a/java/src/json/ext/Parser.rl
+++ b/java/src/json/ext/Parser.rl
@@ -303,6 +303,7 @@ public class Parser extends RubyObject {
         private final Parser parser;
         private final ThreadContext context;
         private final ByteList byteList;
+        private final ByteList view;
         private final byte[] data;
         private final StringDecoder decoder;
         private int currentNesting = 0;
@@ -317,6 +318,7 @@ public class Parser extends RubyObject {
             this.context = context;
             this.byteList = parser.checkAndGetSource().getByteList();
             this.data = byteList.unsafeBytes();
+            this.view = new ByteList(data, false);
             this.decoder = new StringDecoder(context);
             this.dc = new DoubleConverter();
         }
@@ -796,6 +798,7 @@ public class Parser extends RubyObject {
             %% write exec;
 
             if (cs < JSON_object_first_final) {
+                res.update(null, p + 1);
                 return;
             }
 
@@ -928,14 +931,14 @@ public class Parser extends RubyObject {
         }
 
         /**
-         * Returns a subsequence of the source ByteList, based on source
-         * array byte offsets (i.e., the ByteList's own begin offset is not
-         * automatically added).
+         * Updates the "view" bytelist with the new offsets and returns it.
          * @param start
          * @param end
          */
         private ByteList absSubSequence(int absStart, int absEnd) {
-            return new ByteList(byteList.unsafeBytes(), absStart, absEnd - absStart, false);
+            view.setBegin(absStart);
+            view.setRealSize(absEnd - absStart);
+            return view;
         }
 
         /**


### PR DESCRIPTION
You were too quick for me to get this last tweak in! It eliminates construction of ByteList objects solely for Integer/Float parsing, further reducing overhead on JRuby.

Conflicts:

```
java/src/json/ext/Parser.java
java/src/json/ext/Parser.rl
```
