### PR TITLE
Add test-unit as test group dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,7 @@ gemspec :name => 'json-java'
 group :development do
   gem 'simplecov', :platform => :mri_19
 end
+
+group :test do
+  gem 'test-unit', :platform => :mri_19
+end


### PR DESCRIPTION
When we run 'rake test' through bundler like 'bundle exec rake test', we
need test-unit gem installed.  It's because testrb in bundler gem
activates 'test-unit' gem in contrast stock testrb in Ruby dist doesn't.

I'm suspecting it's a bug of bundler but it might be good to add
'test-unit' to Gemfile for a workaround because Gemfile is for bundler.
