### PR TITLE
JRuby in 1.9 mode makes all strings ascii-8bit instead of source encoding

### DIFF
--- a/java/src/json/ext/StringDecoder.java
+++ b/java/src/json/ext/StringDecoder.java
@@ -31,6 +31,7 @@ final class StringDecoder extends ByteListTranscoder {
 
     ByteList decode(ByteList src, int start, int end) {
         ByteList out = new ByteList(end - start);
+        out.setEncoding(src.getEncoding());
         init(src, start, end, out);
         while (hasNext()) {
             handleChar(readUtf8Char());


### PR DESCRIPTION
This will solve reported issues involving encoding like:

https://jira.codehaus.org/browse/JRUBY-6033

And spec failures in master for money gem.  In 1.9 mode we have an extra encoding field.  In 1.8 mode we still have this field, but it is unused.  So this patch is safe in both modes.
