### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  - rbx
-  - rbx-2.0
+  - rbx-18mode
+  - rbx-19mode
   - ree
-  - jruby
+  - jruby-18mode
+  - jruby-19mode
+  - jruby-head
   - ruby-head
 
 script: "bundle exec rake"


### PR DESCRIPTION
Both Rubinius instances we provide (in 1.8 and 1.9 mode) are now 2.0. Same for JRuby, two versions in 2 Ruby modes are available. Plus, jruby-head.
