### PR TITLE
JSON.dump vs. #to_json inconsistency

### DIFF
--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -355,7 +355,7 @@ module JSON
   end
   self.dump_default_options = {
     :max_nesting => false,
-    :allow_nan   => true,
+    :allow_nan   => false,
     :quirks_mode => true,
   }
 


### PR DESCRIPTION
Look, 

```
zsh% ruby -rjson -e'p [0.0/0.0].to_json'
-e:1:in `to_json': 778: NaN not allowed in JSON (JSON::GeneratorError)
        from -e:1:in `<main>'
```

it raises error but,

```
zsh% ruby -rjson -e'JSON.dump([0.0/0.0], STDOUT)'
[NaN]
```

this one doesn't.

I'm not against the ability of dumping `NaN`s but this is quite confusing.  Please let them behave the same.
