### PR TITLE
Remove unused variable

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -629,7 +629,6 @@ static VALUE cState_to_h(VALUE self)
 */
 static VALUE cState_aref(VALUE self, VALUE name)
 {
-    GET_STATE(self);
     if (RTEST(rb_funcall(self, i_respond_to_p, 1, name))) {
         return rb_funcall(self, i_send, 1, name);
     } else {


### PR DESCRIPTION
Please remove unnecessary GET_STATE(self) to avoid an unused-but-set-variable warning in gcc 4.6.
