### PR TITLE
Fix CFLAGS options in ext/json/ext/{generator,parser}/extconf.rb

### DIFF
--- a/ext/json/ext/generator/extconf.rb
+++ b/ext/json/ext/generator/extconf.rb
@@ -1,13 +1,9 @@
 require 'mkmf'
 
-unless $CFLAGS.gsub!(/ -O[\dsz]?/, ' -O3')
-  $CFLAGS << ' -O3'
-end
+$CFLAGS << ' -O3'
 if CONFIG['CC'] =~ /gcc/
   $CFLAGS << ' -Wall'
-  if $DEBUG && !$CFLAGS.gsub!(/ -O[\dsz]?/, ' -O0 -ggdb')
-    $CFLAGS << ' -O0 -ggdb'
-  end
+  $CFLAGS << ' -O0 -ggdb' if $DEBUG
 end
 
 $defs << "-DJSON_GENERATOR"

--- a/ext/json/ext/parser/extconf.rb
+++ b/ext/json/ext/parser/extconf.rb
@@ -1,13 +1,9 @@
 require 'mkmf'
 
-unless $CFLAGS.gsub!(/ -O[\dsz]?/, ' -O3')
-  $CFLAGS << ' -O3'
-end
+$CFLAGS << ' -O3'
 if CONFIG['CC'] =~ /gcc/
   $CFLAGS << ' -Wall'
-  if $DEBUG && !$CFLAGS.gsub!(/ -O[\dsz]?/, ' -O0 -ggdb')
-    $CFLAGS << ' -O0 -ggdb'
-  end
+  $CFLAGS << ' -O0 -ggdb' if $DEBUG
 end
 
 create_makefile 'json/ext/parser'


### PR DESCRIPTION
`ext/json/ext/{generator,parser}/extconf.rb` have some problems.
1. [generator/extconf.rb](https://github.com/flori/json/blob/18261880e33b9bd70152d860ea88c784ebef07e4/ext/json/ext/generator/extconf.rb#L8-10) enables `-O0  -ggdb` when $DEBUG is false.
2. When $CFLAGS contains <code> -Ofast</code>, extconf.rb replaces it with `-O3fast`. It is invalid and causes compile error.

This patch fixes these two problems.
