### PR TITLE
Suppress warning: -Wchar-subscripts

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -902,8 +902,8 @@ static int isArrayOrObject(VALUE string)
     long string_len = RSTRING_LEN(string);
     char *p = RSTRING_PTR(string), *q = p + string_len - 1;
     if (string_len < 2) return 0;
-    for (; p < q && isspace(*p); p++);
-    for (; q > p && isspace(*q); q--);
+    for (; p < q && isspace((unsigned char)*p); p++);
+    for (; q > p && isspace((unsigned char)*q); q--);
     return (*p == '[' && *q == ']') || (*p == '{' && *q == '}');
 }
 


### PR DESCRIPTION
On some platforms char is signed char and giving signed char to
isspace(int c) can cause unexpected behavior.
To avoid such situation, it should cast as unsigned char.
