### PR TITLE
Keep Makefile out of git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Gemfile.lock
 *.rbc
 .rbx
 .AppleDouble
+Makefile


### PR DESCRIPTION
I added `Makefile` to `.gitignore` to safely keep the generated makefile out of git version control.
