### PR TITLE
Removed unnecessary and incorrect condition for Rubinius.

### DIFF
--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -412,10 +412,7 @@ module JSON
   end
 
   # Shortuct for iconv.
-  if ::String.method_defined?(:encode) &&
-    # XXX Rubinius doesn't support ruby 1.9 encoding yet
-    defined?(RUBY_ENGINE) && RUBY_ENGINE != 'rbx'
-  then
+  if ::String.method_defined?(:encode)
     # Encodes string using Ruby's _String.encode_
     def self.iconv(to, from, string)
       string.encode(to, from)


### PR DESCRIPTION
Rubinius has supported Encoding for a long time in 1.9/2.0 mode. This is a critical bug in the json gem that prevents its use with Rubinius in 2.0 mode because the iconv library has been removed.
