### PR TITLE
Remove Rubinius workaround since it actually breaks on Rubinius

### DIFF
--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -412,10 +412,7 @@ module JSON
   end
 
   # Shortuct for iconv.
-  if ::String.method_defined?(:encode) &&
-    # XXX Rubinius doesn't support ruby 1.9 encoding yet
-    defined?(RUBY_ENGINE) && RUBY_ENGINE != 'rbx'
-  then
+  if ::String.method_defined?(:encode)
     # Encodes string using Ruby's _String.encode_
     def self.iconv(to, from, string)
       string.encode(to, from)


### PR DESCRIPTION
Encoding support in Rubinius works well enough that this check is not needed. In 2.x modes, it even breaks things because iconv is not available anymore and it breaks on Rubinius with the following exception:

```
An exception occurred running /Users/dirkjan/Code/rubinius/lib/bin/gem.rb:

    no such file to load -- iconv (LoadError)

Backtrace:

                         Rubinius::CodeLoader#load_error at kernel/common/codeloader.rb:436
               Rubinius::CodeLoader#resolve_require_path at kernel/common/codeloader.rb:423
                     { } in Rubinius::CodeLoader#require at kernel/common/codeloader.rb:103
                                    Rubinius.synchronize at kernel/bootstrap/rubinius.rb:147
                            Rubinius::CodeLoader#require at kernel/common/codeloader.rb:102
                            Rubinius::CodeLoader.require at kernel/common/codeloader.rb:237
           Kernel(Module)#gem_original_require (require) at kernel/common/kernel.rb:686
                                  Kernel(Module)#require at lib/rubygems/core_ext/kernel_require.rb:53
                        { } in Object(Module)#__script__ at gems/gems/json-1.8.0/lib/json/common.rb:424
```
