### PR TITLE
JSON marshalling support for Set and SortedSet

### DIFF
--- a/lib/json/add/set.rb
+++ b/lib/json/add/set.rb
@@ -1,0 +1,29 @@
+unless defined?(::JSON::JSON_LOADED) and ::JSON::JSON_LOADED
+  require 'json'
+end
+defined?(::Set) or require 'set'
+
+class Set
+  # Import a JSON Marshalled object.
+  #
+  # method used for JSON marshalling support.
+  def self.json_create(object)
+    new object['a']
+  end
+
+  # Marshal the object to JSON.
+  #
+  # method used for JSON marshalling support.
+  def as_json(*)
+    {
+      JSON.create_id => self.class.name,
+      'a'            => to_a,
+    }
+  end
+
+  # return the JSON value
+  def to_json(*args)
+    as_json.to_json(*args)
+  end
+end
+

--- a/tests/test_json_addition.rb
+++ b/tests/test_json_addition.rb
@@ -8,6 +8,7 @@ require 'json/add/complex'
 require 'json/add/rational'
 require 'json/add/bigdecimal'
 require 'json/add/ostruct'
+require 'json/add/set'
 require 'date'
 
 class TestJSONAddition < Test::Unit::TestCase
@@ -192,5 +193,14 @@ class TestJSONAddition < Test::Unit::TestCase
     # XXX this won't work; o.foo = { :bar => true }
     o.foo = { 'bar' => true }
     assert_equal o, JSON.parse(JSON(o), :create_additions => true)
+  end
+
+  def test_set
+    s = Set.new([:a, :b, :c, :a])
+    assert_equal s, JSON.parse(JSON(s), :create_additions => true)
+    ss = SortedSet.new([:d, :b, :a, :c])
+    ss_again = JSON.parse(JSON(ss), :create_additions => true)
+    assert_kind_of ss.class, ss_again
+    assert_equal ss, ss_again
   end
 end


### PR DESCRIPTION
Support JSON serialization of Set and SortedSet from Ruby standard library, in the style of your existing support for BigDecimal, Time, etc.
Allows the elements of a Set to be reconstructed.
