### PR TITLE
Generation for additional types respect options

### DIFF
--- a/lib/json/add/bigdecimal.rb
+++ b/lib/json/add/bigdecimal.rb
@@ -22,7 +22,7 @@ class BigDecimal
   end
 
   # return the JSON value
-  def to_json(*)
-    as_json.to_json
+  def to_json(*args)
+    as_json.to_json(*args)
   end
 end

--- a/lib/json/add/complex.rb
+++ b/lib/json/add/complex.rb
@@ -16,7 +16,7 @@ class Complex
     }
   end
 
-  def to_json(*)
-    as_json.to_json
+  def to_json(*args)
+    as_json.to_json(*args)
   end
 end

--- a/lib/json/add/rational.rb
+++ b/lib/json/add/rational.rb
@@ -16,7 +16,7 @@ class Rational
     }
   end
 
-  def to_json(*)
-    as_json.to_json
+  def to_json(*args)
+    as_json.to_json(*args)
   end
 end

--- a/lib/json/add/regexp.rb
+++ b/lib/json/add/regexp.rb
@@ -24,7 +24,7 @@ class Regexp
 
   # Stores class name (Regexp) with options <tt>o</tt> and source <tt>s</tt>
   # (Regexp or String) as JSON string
-  def to_json(*)
-    as_json.to_json
+  def to_json(*args)
+    as_json.to_json(*args)
   end
 end


### PR DESCRIPTION
JSON serialization of `BigDecimal`, `Complex`, `Rational`, and `Regexp` now pass along
the options to handle, for example, pretty printing with `jj`.

From your documentation "don’t forget the *a for all the arguments" I think this is considered best practice, and many of the other classes you support, _e.g._ `Data`, `Exception`, already do this.
