### PR TITLE
Call `to_json` on the object to allow overridden methods the first shot

### DIFF
--- a/java/src/json/ext/GeneratorState.java
+++ b/java/src/json/ext/GeneratorState.java
@@ -207,7 +207,8 @@ public class GeneratorState extends RubyObject {
      */
     @JRubyMethod
     public IRubyObject generate(ThreadContext context, IRubyObject obj) {
-        RubyString result = Generator.generateJson(context, obj, this);
+        RubyString result = (RubyString)obj.callMethod(context, "to_json", this);
+
         if (!quirksMode && !objectOrArrayLiteral(result)) {
             throw Utils.newException(context, Utils.M_GENERATOR_ERROR,
                     "only generation of JSON objects or arrays allowed");


### PR DESCRIPTION
ActiveSupport will call `merge` on the GeneratorState, which resets
the depth back to 0. Then we decrement it again and pass that negative
value to System.arraycopy, which throws an exception.

This fixes the problem in the same way as the pure JSON code: it calls
`to_json` on the passed-in object. This method is implemented /
overridden by ActiveSupport, which then ignores the pretty-printing
completely.
