### PR TITLE
Ruby and C implementations now escape U+2028/2029.

### DIFF
--- a/lib/json/pure/generator.rb
+++ b/lib/json/pure/generator.rb
@@ -35,6 +35,10 @@ module JSON
     '"'   =>  '\"',
     '\\'  =>  '\\\\',
   } # :nodoc:
+  MAP2 = {
+    "\u2028" => '\\u2028',
+    "\u2029" => '\\u2029'
+  }
 
   # Convert a UTF8 encoded Ruby string _string_ to a JSON string, encoded with
   # UTF16 big endian characters as \u????, and return it.
@@ -44,7 +48,10 @@ module JSON
       string.force_encoding(::Encoding::ASCII_8BIT)
       string.gsub!(/["\\\x0-\x1f]/) { MAP[$&] }
       string.force_encoding(::Encoding::UTF_8)
+      string.gsub!(/[\u2028-\u2029]/) { MAP2[$&] }
       string
+    rescue => e
+      raise GeneratorError.wrap(e)
     end
 
     def utf8_to_json_ascii(string) # :nodoc:
@@ -79,11 +86,11 @@ module JSON
     module_function :valid_utf8?
   else
     def utf8_to_json(string) # :nodoc:
-      string.gsub(/["\\\x0-\x1f]/n) { MAP[$&] }
+      string.gsub(/["\\\x0-\x1f]/n) { MAP[$&] }.gsub(/[\u2028-\u2029]/) { MAP2[$&] }
     end
 
     def utf8_to_json_ascii(string) # :nodoc:
-      string = string.gsub(/["\\\x0-\x1f]/) { MAP[$&] }
+      string = string.gsub(/["\\\x0-\x1f]/) { MAP[$&] }.gsub(/[\u2028-\u2029]/) { MAP2[$&] }
       string.gsub!(/(
                       (?:
                         [\xc2-\xdf][\x80-\xbf]    |

--- a/tests/test_json_unicode.rb
+++ b/tests/test_json_unicode.rb
@@ -46,6 +46,8 @@ class TestJSONUnicode < Test::Unit::TestCase
     json = '["\ud840\udc01"]'
     assert_equal json, JSON.generate(utf8, :ascii_only => true)
     assert_equal utf8, JSON.parse(json)
+    assert_equal "\"\\u2028\"", "\u2028".to_json
+    assert_equal "\"\\u2029\"", "\u2029".to_json
   end
 
   def test_chars


### PR DESCRIPTION
This is a fix for Issue #214.

I modified the library to detect \u2028 and \u2029 within Ruby strings and escape those into their \u2028 and \u2029 counterparts. The test_json_unicode.rb was updated for these two conditions.
