### PR TITLE
Don't mutate JSON.dump_default_options from dump

### DIFF
--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -390,7 +390,7 @@ module JSON
       end
     end
     opts = JSON.dump_default_options
-    limit and opts.update(:max_nesting => limit)
+    opts = opts.merge(:max_nesting => limit) if limit
     result = generate(obj, opts)
     if anIO
       anIO.write result

--- a/tests/test_json.rb
+++ b/tests/test_json.rb
@@ -515,6 +515,12 @@ EOT
     assert_equal too_deep, output.string
   end
 
+  def test_dump_should_modify_defaults
+    max_nesting = JSON.dump_default_options[:max_nesting]
+    JSON.dump([], StringIO.new, 10)
+    assert_equal max_nesting, JSON.dump_default_options[:max_nesting]
+  end
+
   def test_big_integers
     json1 = JSON([orig = (1 << 31) - 1])
     assert_equal orig, JSON[json1][0]


### PR DESCRIPTION
The use of `Hash#update` from the `JSON.dump` method was mutating the
`dump_default_options` hash on any call to `dump` with a `limit` provided. An
individual method call with an overriding value shouldn't update the defaults
in this way.
