### PR TITLE
RFC7159 mode

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -16,7 +16,7 @@ static ID i_to_s, i_to_json, i_new, i_indent, i_space, i_space_before,
           i_object_nl, i_array_nl, i_max_nesting, i_allow_nan, i_ascii_only,
           i_quirks_mode, i_pack, i_unpack, i_create_id, i_extend, i_key_p,
           i_aref, i_send, i_respond_to_p, i_match, i_keys, i_depth,
-          i_buffer_initial_length, i_dup;
+          i_buffer_initial_length, i_dup, i_standards_mode;
 
 /*
  * Copyright 2001-2004 Unicode, Inc.
@@ -603,6 +603,8 @@ static VALUE cState_configure(VALUE self, VALUE opts)
     state->ascii_only = RTEST(tmp);
     tmp = rb_hash_aref(opts, ID2SYM(i_quirks_mode));
     state->quirks_mode = RTEST(tmp);
+    tmp = rb_hash_aref(opts, ID2SYM(i_standards_mode));
+    state->standards_mode = RTEST(tmp);
     return self;
 }
 
@@ -637,6 +639,7 @@ static VALUE cState_to_h(VALUE self)
     rb_hash_aset(result, ID2SYM(i_allow_nan), state->allow_nan ? Qtrue : Qfalse);
     rb_hash_aset(result, ID2SYM(i_ascii_only), state->ascii_only ? Qtrue : Qfalse);
     rb_hash_aset(result, ID2SYM(i_quirks_mode), state->quirks_mode ? Qtrue : Qfalse);
+    rb_hash_aset(result, ID2SYM(i_standards_mode), state->standards_mode ? Qtrue : Qfalse);
     rb_hash_aset(result, ID2SYM(i_max_nesting), LONG2FIX(state->max_nesting));
     rb_hash_aset(result, ID2SYM(i_depth), LONG2FIX(state->depth));
     rb_hash_aset(result, ID2SYM(i_buffer_initial_length), LONG2FIX(state->buffer_initial_length));
@@ -918,7 +921,7 @@ static VALUE cState_generate(VALUE self, VALUE obj)
 {
     VALUE result = cState_partial_generate(self, obj);
     GET_STATE(self);
-    if (!state->quirks_mode && !isArrayOrObject(result)) {
+    if (!state->quirks_mode && !state->standards_mode && !isArrayOrObject(result)) {
         rb_raise(eGeneratorError, "only generation of JSON objects or arrays allowed");
     }
     return result;
@@ -941,6 +944,8 @@ static VALUE cState_generate(VALUE self, VALUE obj)
  *   encountered. This options defaults to false.
  * * *quirks_mode*: Enables quirks_mode for parser, that is for example
  *   generating single JSON values instead of documents is possible.
+ * * *standards_mode*: Enables JSON parsing according to rfc7159 (rather
+ *   than rfc4627 which is the default)
  * * *buffer_initial_length*: sets the initial length of the generator's
  *   internal buffer.
  */
@@ -1258,6 +1263,17 @@ static VALUE cState_quirks_mode_p(VALUE self)
 }
 
 /*
+ * call-seq: standards_mode?
+ *
+ * Returns true, if standards mode is enabled. Otherwise returns false.
+ */
+static VALUE cState_standards_mode_p(VALUE self)
+{
+    GET_STATE(self);
+    return state->standards_mode ? Qtrue : Qfalse;
+}
+
+/*
  * call-seq: quirks_mode=(enable)
  *
  * If set to true, enables the quirks_mode mode.
@@ -1266,6 +1282,18 @@ static VALUE cState_quirks_mode_set(VALUE self, VALUE enable)
 {
     GET_STATE(self);
     state->quirks_mode = RTEST(enable);
+    return Qnil;
+}
+
+/*
+ * call-seq: standards_mode=(enable)
+ *
+ * If set to true, enables the standards_mode mode.
+ */
+static VALUE cState_standards_mode_set(VALUE self, VALUE enable)
+{
+    GET_STATE(self);
+    state->standards_mode = RTEST(enable);
     return Qnil;
 }
 
@@ -1360,6 +1388,9 @@ void Init_generator()
     rb_define_method(cState, "quirks_mode?", cState_quirks_mode_p, 0);
     rb_define_method(cState, "quirks_mode", cState_quirks_mode_p, 0);
     rb_define_method(cState, "quirks_mode=", cState_quirks_mode_set, 1);
+    rb_define_method(cState, "standards_mode?", cState_standards_mode_p, 0);
+    rb_define_method(cState, "standards_mode", cState_standards_mode_p, 0);
+    rb_define_method(cState, "standards_mode=", cState_standards_mode_set, 1);
     rb_define_method(cState, "depth", cState_depth, 0);
     rb_define_method(cState, "depth=", cState_depth_set, 1);
     rb_define_method(cState, "buffer_initial_length", cState_buffer_initial_length, 0);
@@ -1412,6 +1443,7 @@ void Init_generator()
     i_allow_nan = rb_intern("allow_nan");
     i_ascii_only = rb_intern("ascii_only");
     i_quirks_mode = rb_intern("quirks_mode");
+    i_standards_mode = rb_intern("standards_mode");
     i_depth = rb_intern("depth");
     i_buffer_initial_length = rb_intern("buffer_initial_length");
     i_pack = rb_intern("pack");

--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -74,6 +74,7 @@ typedef struct JSON_Generator_StateStruct {
     char allow_nan;
     char ascii_only;
     char quirks_mode;
+    char standards_mode;
     long depth;
     long buffer_initial_length;
 } JSON_Generator_State;

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -81,7 +81,7 @@ static VALUE CNaN, CInfinity, CMinusInfinity;
 static ID i_json_creatable_p, i_json_create, i_create_id, i_create_additions,
           i_chr, i_max_nesting, i_allow_nan, i_symbolize_names, i_quirks_mode,
           i_object_class, i_array_class, i_key_p, i_deep_const_get, i_match,
-          i_match_string, i_aset, i_aref, i_leftshift;
+          i_match_string, i_aset, i_aref, i_leftshift, i_standards_mode;
 
 
 #line 110 "parser.rl"
@@ -524,7 +524,7 @@ tr2:
 #line 224 "parser.rl"
 	{
         char *np;
-        if(pe > p + 9 - json->quirks_mode && !strncmp(MinusInfinity, p, 9)) {
+        if(pe > p + 9 - ((json->quirks_mode || json->standards_mode) ? 1 : 0) && !strncmp(MinusInfinity, p, 9)) {
             if (json->allow_nan) {
                 *result = CMinusInfinity;
                 {p = (( p + 10))-1;}
@@ -1564,11 +1564,11 @@ case 7:
  *
  */
 
-static VALUE convert_encoding(VALUE source)
+static VALUE convert_encoding2(VALUE source, int allow_values)
 {
     char *ptr = RSTRING_PTR(source);
     long len = RSTRING_LEN(source);
-    if (len < 2) {
+    if (len < 2 && !allow_values) {
         rb_raise(eParserError, "A JSON text must at least contain two octets!");
     }
 #ifdef HAVE_RUBY_ENCODING_H
@@ -1603,6 +1603,11 @@ static VALUE convert_encoding(VALUE source)
     }
 #endif
     return source;
+}
+
+static VALUE convert_encoding(VALUE source)
+{
+  return convert_encoding2(source, Qfalse);
 }
 
 /*
@@ -1676,6 +1681,12 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
             } else {
                 json->quirks_mode = 0;
             }
+            tmp = ID2SYM(i_standards_mode);
+            if (option_given_p(opts, tmp)) {
+                json->standards_mode = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
+            } else {
+                json->standards_mode = 0;
+            }
             tmp = ID2SYM(i_create_additions);
             if (option_given_p(opts, tmp)) {
                 json->create_additions = RTEST(rb_hash_aref(opts, tmp));
@@ -1718,7 +1729,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
     }
     source = rb_convert_type(source, T_STRING, "String", "to_str");
     if (!json->quirks_mode) {
-      source = convert_encoding(StringValue(source));
+      source = convert_encoding2(StringValue(source), json->standards_mode);
     }
     json->current_nesting = 0;
     StringValue(source);
@@ -1729,7 +1740,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 
-#line 1733 "parser.c"
+#line 1744 "parser.c"
 static const int JSON_start = 1;
 static const int JSON_first_final = 10;
 static const int JSON_error = 0;
@@ -1737,7 +1748,7 @@ static const int JSON_error = 0;
 static const int JSON_en_main = 1;
 
 
-#line 740 "parser.rl"
+#line 751 "parser.rl"
 
 
 static VALUE cParser_parse_strict(VALUE self)
@@ -1748,16 +1759,16 @@ static VALUE cParser_parse_strict(VALUE self)
     GET_PARSER;
 
 
-#line 1752 "parser.c"
+#line 1763 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 750 "parser.rl"
+#line 761 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 1761 "parser.c"
+#line 1772 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1813,7 +1824,7 @@ case 5:
 		goto st1;
 	goto st5;
 tr3:
-#line 729 "parser.rl"
+#line 740 "parser.rl"
 	{
         char *np;
         json->current_nesting = 1;
@@ -1822,7 +1833,7 @@ tr3:
     }
 	goto st10;
 tr4:
-#line 722 "parser.rl"
+#line 733 "parser.rl"
 	{
         char *np;
         json->current_nesting = 1;
@@ -1834,7 +1845,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 1838 "parser.c"
+#line 1849 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -1891,7 +1902,7 @@ case 9:
 	_out: {}
 	}
 
-#line 753 "parser.rl"
+#line 764 "parser.rl"
 
     if (cs >= JSON_first_final && p == pe) {
         return result;
@@ -1903,18 +1914,18 @@ case 9:
 
 
 
-#line 1907 "parser.c"
-static const int JSON_quirks_mode_start = 1;
-static const int JSON_quirks_mode_first_final = 10;
-static const int JSON_quirks_mode_error = 0;
+#line 1918 "parser.c"
+static const int JSON_text_start = 1;
+static const int JSON_text_first_final = 10;
+static const int JSON_text_error = 0;
 
-static const int JSON_quirks_mode_en_main = 1;
-
-
-#line 778 "parser.rl"
+static const int JSON_text_en_main = 1;
 
 
-static VALUE cParser_parse_quirks_mode(VALUE self)
+#line 789 "parser.rl"
+
+
+static VALUE cParser_parse_json_text(VALUE self)
 {
     char *p, *pe;
     int cs = EVIL;
@@ -1922,16 +1933,16 @@ static VALUE cParser_parse_quirks_mode(VALUE self)
     GET_PARSER;
 
 
-#line 1926 "parser.c"
+#line 1937 "parser.c"
 	{
-	cs = JSON_quirks_mode_start;
+	cs = JSON_text_start;
 	}
 
-#line 788 "parser.rl"
+#line 799 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 1935 "parser.c"
+#line 1946 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1965,7 +1976,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 770 "parser.rl"
+#line 781 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -1975,7 +1986,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 1979 "parser.c"
+#line 1990 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2064,9 +2075,9 @@ case 9:
 	_out: {}
 	}
 
-#line 791 "parser.rl"
+#line 802 "parser.rl"
 
-    if (cs >= JSON_quirks_mode_first_final && p == pe) {
+    if (cs >= JSON_text_first_final && p == pe) {
         return result;
     } else {
         rb_raise(eParserError, "%u: unexpected token at '%s'", __LINE__, p);
@@ -2084,8 +2095,8 @@ static VALUE cParser_parse(VALUE self)
 {
   GET_PARSER;
 
-  if (json->quirks_mode) {
-    return cParser_parse_quirks_mode(self);
+  if (json->quirks_mode || json->standards_mode) {
+    return cParser_parse_json_text(self);
   } else {
     return cParser_parse_strict(self);
   }
@@ -2144,6 +2155,16 @@ static VALUE cParser_quirks_mode_p(VALUE self)
     return json->quirks_mode ? Qtrue : Qfalse;
 }
 
+/*
+ * call-seq: standards_mode?()
+ *
+ * Returns a true, if this parser is in standards_mode, false otherwise.
+ */
+static VALUE cParser_standards_mode_p(VALUE self)
+{
+    GET_PARSER;
+    return json->standards_mode ? Qtrue : Qfalse;
+}
 
 void Init_parser()
 {
@@ -2158,6 +2179,7 @@ void Init_parser()
     rb_define_method(cParser, "parse", cParser_parse, 0);
     rb_define_method(cParser, "source", cParser_source, 0);
     rb_define_method(cParser, "quirks_mode?", cParser_quirks_mode_p, 0);
+    rb_define_method(cParser, "standards_mode?", cParser_standards_mode_p, 0);
 
     CNaN = rb_const_get(mJSON, rb_intern("NaN"));
     CInfinity = rb_const_get(mJSON, rb_intern("Infinity"));
@@ -2172,6 +2194,7 @@ void Init_parser()
     i_allow_nan = rb_intern("allow_nan");
     i_symbolize_names = rb_intern("symbolize_names");
     i_quirks_mode = rb_intern("quirks_mode");
+    i_standards_mode = rb_intern("standards_mode");
     i_object_class = rb_intern("object_class");
     i_array_class = rb_intern("array_class");
     i_match = rb_intern("match");

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -75,7 +75,7 @@ static ID i_encoding, i_encode;
 static ID i_iconv;
 #endif
 
-static VALUE mJSON, mExt, cParser, eParserError, eNestingError;
+static VALUE mJSON, mExt, cParser, eParserError, eNestingError, eEncodingError;
 static VALUE CNaN, CInfinity, CMinusInfinity;
 
 static ID i_json_creatable_p, i_json_create, i_create_id, i_create_additions,
@@ -1568,8 +1568,10 @@ static VALUE convert_encoding2(VALUE source, int allow_values)
 {
     char *ptr = RSTRING_PTR(source);
     long len = RSTRING_LEN(source);
-    if (len < 2 && !allow_values) {
-        rb_raise(eParserError, "A JSON text must at least contain two octets!");
+    if (allow_values) {
+        if (len < 1) rb_raise(eEncodingError, "A JSON text must at least contain one octet!");
+    } else {
+        if (len < 2) rb_raise(eEncodingError, "A JSON text must at least contain two octets!");
     }
 #ifdef HAVE_RUBY_ENCODING_H
     {
@@ -1740,7 +1742,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 
-#line 1744 "parser.c"
+#line 1746 "parser.c"
 static const int JSON_start = 1;
 static const int JSON_first_final = 10;
 static const int JSON_error = 0;
@@ -1748,7 +1750,7 @@ static const int JSON_error = 0;
 static const int JSON_en_main = 1;
 
 
-#line 751 "parser.rl"
+#line 753 "parser.rl"
 
 
 static VALUE cParser_parse_strict(VALUE self)
@@ -1759,16 +1761,16 @@ static VALUE cParser_parse_strict(VALUE self)
     GET_PARSER;
 
 
-#line 1763 "parser.c"
+#line 1765 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 761 "parser.rl"
+#line 763 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 1772 "parser.c"
+#line 1774 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1824,7 +1826,7 @@ case 5:
 		goto st1;
 	goto st5;
 tr3:
-#line 740 "parser.rl"
+#line 742 "parser.rl"
 	{
         char *np;
         json->current_nesting = 1;
@@ -1833,7 +1835,7 @@ tr3:
     }
 	goto st10;
 tr4:
-#line 733 "parser.rl"
+#line 735 "parser.rl"
 	{
         char *np;
         json->current_nesting = 1;
@@ -1845,7 +1847,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 1849 "parser.c"
+#line 1851 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -1902,7 +1904,7 @@ case 9:
 	_out: {}
 	}
 
-#line 764 "parser.rl"
+#line 766 "parser.rl"
 
     if (cs >= JSON_first_final && p == pe) {
         return result;
@@ -1914,7 +1916,7 @@ case 9:
 
 
 
-#line 1918 "parser.c"
+#line 1920 "parser.c"
 static const int JSON_text_start = 1;
 static const int JSON_text_first_final = 10;
 static const int JSON_text_error = 0;
@@ -1922,7 +1924,7 @@ static const int JSON_text_error = 0;
 static const int JSON_text_en_main = 1;
 
 
-#line 789 "parser.rl"
+#line 791 "parser.rl"
 
 
 static VALUE cParser_parse_json_text(VALUE self)
@@ -1933,16 +1935,16 @@ static VALUE cParser_parse_json_text(VALUE self)
     GET_PARSER;
 
 
-#line 1937 "parser.c"
+#line 1939 "parser.c"
 	{
 	cs = JSON_text_start;
 	}
 
-#line 799 "parser.rl"
+#line 801 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 1946 "parser.c"
+#line 1948 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1976,7 +1978,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 781 "parser.rl"
+#line 783 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -1986,7 +1988,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 1990 "parser.c"
+#line 1992 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2075,7 +2077,7 @@ case 9:
 	_out: {}
 	}
 
-#line 802 "parser.rl"
+#line 804 "parser.rl"
 
     if (cs >= JSON_text_first_final && p == pe) {
         return result;
@@ -2174,6 +2176,7 @@ void Init_parser()
     cParser = rb_define_class_under(mExt, "Parser", rb_cObject);
     eParserError = rb_path2class("JSON::ParserError");
     eNestingError = rb_path2class("JSON::NestingError");
+    eEncodingError = rb_path2class("JSON::EncodingError");
     rb_define_alloc_func(cParser, cJSON_parser_s_allocate);
     rb_define_method(cParser, "initialize", cParser_initialize, -1);
     rb_define_method(cParser, "parse", cParser_parse, 0);

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -1627,7 +1627,7 @@ static VALUE convert_encoding(VALUE source)
  *   the default.
  * * *create_additions*: If set to false, the Parser doesn't create
  *   additions even if a matching class and create_id was found. This option
- *   defaults to false.
+ *   defaults to true.
  * * *object_class*: Defaults to Hash
  * * *array_class*: Defaults to Array
  */

--- a/ext/json/ext/parser/parser.h
+++ b/ext/json/ext/parser/parser.h
@@ -39,6 +39,7 @@ typedef struct JSON_ParserStruct {
     int parsing_name;
     int symbolize_names;
     int quirks_mode;
+    int standards_mode;
     VALUE object_class;
     VALUE array_class;
     int create_additions;

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -73,7 +73,7 @@ static ID i_encoding, i_encode;
 static ID i_iconv;
 #endif
 
-static VALUE mJSON, mExt, cParser, eParserError, eNestingError;
+static VALUE mJSON, mExt, cParser, eParserError, eNestingError, eEncodingError;
 static VALUE CNaN, CInfinity, CMinusInfinity;
 
 static ID i_json_creatable_p, i_json_create, i_create_id, i_create_additions,
@@ -552,8 +552,10 @@ static VALUE convert_encoding2(VALUE source, int allow_values)
 {
     char *ptr = RSTRING_PTR(source);
     long len = RSTRING_LEN(source);
-    if (len < 2 && !allow_values) {
-        rb_raise(eParserError, "A JSON text must at least contain two octets!");
+    if (allow_values) {
+        if (len < 1) rb_raise(eEncodingError, "A JSON text must at least contain one octet!");
+    } else {
+        if (len < 2) rb_raise(eEncodingError, "A JSON text must at least contain two octets!");
     }
 #ifdef HAVE_RUBY_ENCODING_H
     {
@@ -897,6 +899,7 @@ void Init_parser()
     cParser = rb_define_class_under(mExt, "Parser", rb_cObject);
     eParserError = rb_path2class("JSON::ParserError");
     eNestingError = rb_path2class("JSON::NestingError");
+    eEncodingError = rb_path2class("JSON::EncodingError");
     rb_define_alloc_func(cParser, cJSON_parser_s_allocate);
     rb_define_method(cParser, "initialize", cParser_initialize, -1);
     rb_define_method(cParser, "parse", cParser_parse, 0);

--- a/java/src/json/ext/GeneratorState.java
+++ b/java/src/json/ext/GeneratorState.java
@@ -84,6 +84,11 @@ public class GeneratorState extends RubyObject {
     private boolean quirksMode = DEFAULT_QUIRKS_MODE;
     static final boolean DEFAULT_QUIRKS_MODE = false;
     /**
+     * If set to <code>true</code> JSON is parsed according to rfc7159.
+     */
+    private boolean standardsMode = DEFAULT_STANDARDS_MODE;
+    static final boolean DEFAULT_STANDARDS_MODE = false;
+    /**
      * The initial buffer length of this state. (This isn't really used on all
      * non-C implementations.)
      */
@@ -195,6 +200,7 @@ public class GeneratorState extends RubyObject {
         this.allowNaN = orig.allowNaN;
         this.asciiOnly = orig.asciiOnly;
         this.quirksMode = orig.quirksMode;
+        this.standardsMode = orig.standardsMode;
         this.bufferInitialLength = orig.bufferInitialLength;
         this.depth = orig.depth;
         return this;
@@ -208,7 +214,7 @@ public class GeneratorState extends RubyObject {
     @JRubyMethod
     public IRubyObject generate(ThreadContext context, IRubyObject obj) {
         RubyString result = Generator.generateJson(context, obj, this);
-        if (!quirksMode && !objectOrArrayLiteral(result)) {
+        if (!quirksMode && !standardsMode && !objectOrArrayLiteral(result)) {
             throw Utils.newException(context, Utils.M_GENERATOR_ERROR,
                     "only generation of JSON objects or arrays allowed");
         }
@@ -410,6 +416,27 @@ public class GeneratorState extends RubyObject {
         return quirks_mode.getRuntime().newBoolean(quirksMode);
     }
 
+    @JRubyMethod(name="quirks_mode?")
+    public RubyBoolean quirks_mode_p(ThreadContext context) {
+        return context.getRuntime().newBoolean(quirksMode);
+    }
+
+    @JRubyMethod(name="standards_mode")
+    public RubyBoolean standards_mode_get(ThreadContext context) {
+        return context.getRuntime().newBoolean(standardsMode);
+    }
+
+    @JRubyMethod(name="standards_mode=")
+    public IRubyObject standards_mode_set(IRubyObject standards_mode) {
+        standardsMode = standards_mode.isTrue();
+        return standards_mode.getRuntime().newBoolean(standardsMode);
+    }
+
+    @JRubyMethod(name="standards_mode?")
+    public RubyBoolean standards_mode_p(ThreadContext context) {
+        return context.getRuntime().newBoolean(standardsMode);
+    }
+
     @JRubyMethod(name="buffer_initial_length")
     public RubyInteger buffer_initial_length_get(ThreadContext context) {
         return context.getRuntime().newFixnum(bufferInitialLength);
@@ -420,11 +447,6 @@ public class GeneratorState extends RubyObject {
         int newLength = RubyNumeric.fix2int(buffer_initial_length);
         if (newLength > 0) bufferInitialLength = newLength;
         return buffer_initial_length;
-    }
-
-    @JRubyMethod(name="quirks_mode?")
-    public RubyBoolean quirks_mode_p(ThreadContext context) {
-        return context.getRuntime().newBoolean(quirksMode);
     }
 
     public int getDepth() {
@@ -482,6 +504,7 @@ public class GeneratorState extends RubyObject {
         allowNaN   = opts.getBool("allow_nan",  DEFAULT_ALLOW_NAN);
         asciiOnly  = opts.getBool("ascii_only", DEFAULT_ASCII_ONLY);
         quirksMode = opts.getBool("quirks_mode", DEFAULT_QUIRKS_MODE);
+        standardsMode = opts.getBool("standards_mode", DEFAULT_STANDARDS_MODE);
         bufferInitialLength = opts.getInt("buffer_initial_length", DEFAULT_BUFFER_INITIAL_LENGTH);
 
         depth = opts.getInt("depth", 0);
@@ -509,6 +532,7 @@ public class GeneratorState extends RubyObject {
         result.op_aset(context, runtime.newSymbol("allow_nan"), allow_nan_p(context));
         result.op_aset(context, runtime.newSymbol("ascii_only"), ascii_only_p(context));
         result.op_aset(context, runtime.newSymbol("quirks_mode"), quirks_mode_p(context));
+        result.op_aset(context, runtime.newSymbol("standards_mode"), standards_mode_p(context));
         result.op_aset(context, runtime.newSymbol("max_nesting"), max_nesting_get(context));
         result.op_aset(context, runtime.newSymbol("depth"), depth_get(context));
         result.op_aset(context, runtime.newSymbol("buffer_initial_length"), buffer_initial_length_get(context));

--- a/java/src/json/ext/Parser.java
+++ b/java/src/json/ext/Parser.java
@@ -54,6 +54,7 @@ public class Parser extends RubyObject {
     private boolean allowNaN;
     private boolean symbolizeNames;
     private boolean quirksMode;
+    private boolean standardsMode;
     private RubyClass objectClass;
     private RubyClass arrayClass;
     private RubyHash match_string;
@@ -127,7 +128,11 @@ public class Parser extends RubyObject {
      * <dt><code>:quirks_mode?</code>
      * <dd>If set to <code>true</code>, if the parse is in quirks_mode, false
      * otherwise.
-     * 
+     *
+     * <dt><code>:standards_mode?</code>
+     * <dd>If set to <code>true</code>, if the parse is in rfc7159 standards_mode,
+     * false otherwise.
+     *
      * <dt><code>:create_additions</code>
      * <dd>If set to <code>false</code>, the Parser doesn't create additions
      * even if a matching class and <code>create_id</code> was found. This option
@@ -165,6 +170,7 @@ public class Parser extends RubyObject {
         this.allowNaN        = opts.getBool("allow_nan", false);
         this.symbolizeNames  = opts.getBool("symbolize_names", false);
         this.quirksMode      = opts.getBool("quirks_mode", false);
+        this.standardsMode   = opts.getBool("standards_mode", false);
         this.createId        = opts.getString("create_id", getCreateId(context));
         this.createAdditions = opts.getBool("create_additions", false);
         this.objectClass     = opts.getClass("object_class", runtime.getHash());
@@ -185,9 +191,16 @@ public class Parser extends RubyObject {
     private RubyString convertEncoding(ThreadContext context, RubyString source) {
         ByteList bl = source.getByteList();
         int len = bl.length();
-        if (len < 2) {
-            throw Utils.newException(context, Utils.M_PARSER_ERROR,
-                "A JSON text must at least contain two octets!");
+        if (this.standardsMode) {
+            if (len < 1) {
+                throw Utils.newException(context, Utils.M_ENCODING_ERROR,
+                    "A JSON text must at least contain one octet!");
+            }
+        } else {
+            if (len < 2) {
+                throw Utils.newException(context, Utils.M_ENCODING_ERROR,
+                    "A JSON text must at least contain two octets!");
+            }
         }
 
         if (info.encodingsSupported()) {
@@ -273,6 +286,17 @@ public class Parser extends RubyObject {
         return context.getRuntime().newBoolean(quirksMode);
     }
 
+    /**
+     * <code>Parser#standards_mode?()</code>
+     *
+     * <p>If set to <code>true</code>, if the parse is in rfc7159 standards_mode,
+     * false otherwise.
+     */
+    @JRubyMethod(name = "standards_mode?")
+    public IRubyObject standards_mode_p(ThreadContext context) {
+        return context.getRuntime().newBoolean(standardsMode);
+    }
+
     public RubyString checkAndGetSource() {
       if (vSource != null) {
         return vSource;
@@ -337,11 +361,11 @@ public class Parser extends RubyObject {
         }
 
         
-// line 363 "Parser.rl"
+// line 387 "Parser.rl"
 
 
         
-// line 345 "Parser.java"
+// line 369 "Parser.java"
 private static byte[] init__JSON_value_actions_0()
 {
 	return new byte [] {
@@ -455,7 +479,7 @@ static final int JSON_value_error = 0;
 static final int JSON_value_en_main = 1;
 
 
-// line 469 "Parser.rl"
+// line 493 "Parser.rl"
 
 
         void parseValue(ParserResult res, int p, int pe) {
@@ -463,14 +487,14 @@ static final int JSON_value_en_main = 1;
             IRubyObject result = null;
 
             
-// line 467 "Parser.java"
+// line 491 "Parser.java"
 	{
 	cs = JSON_value_start;
 	}
 
-// line 476 "Parser.rl"
+// line 500 "Parser.rl"
             
-// line 474 "Parser.java"
+// line 498 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -496,13 +520,13 @@ case 1:
 	while ( _nacts-- > 0 ) {
 		switch ( _JSON_value_actions[_acts++] ) {
 	case 9:
-// line 454 "Parser.rl"
+// line 478 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 506 "Parser.java"
+// line 530 "Parser.java"
 		}
 	}
 
@@ -565,25 +589,25 @@ case 1:
 			switch ( _JSON_value_actions[_acts++] )
 			{
 	case 0:
-// line 371 "Parser.rl"
+// line 395 "Parser.rl"
 	{
                 result = getRuntime().getNil();
             }
 	break;
 	case 1:
-// line 374 "Parser.rl"
+// line 398 "Parser.rl"
 	{
                 result = getRuntime().getFalse();
             }
 	break;
 	case 2:
-// line 377 "Parser.rl"
+// line 401 "Parser.rl"
 	{
                 result = getRuntime().getTrue();
             }
 	break;
 	case 3:
-// line 380 "Parser.rl"
+// line 404 "Parser.rl"
 	{
                 if (parser.allowNaN) {
                     result = getConstant(CONST_NAN);
@@ -593,7 +617,7 @@ case 1:
             }
 	break;
 	case 4:
-// line 387 "Parser.rl"
+// line 411 "Parser.rl"
 	{
                 if (parser.allowNaN) {
                     result = getConstant(CONST_INFINITY);
@@ -603,9 +627,9 @@ case 1:
             }
 	break;
 	case 5:
-// line 394 "Parser.rl"
+// line 418 "Parser.rl"
 	{
-                if (pe > p + 9 - (parser.quirksMode ? 1 : 0) &&
+                if (pe > p + 9 - ((parser.quirksMode || parser.standardsMode) ? 1 : 0) &&
                     absSubSequence(p, p + 9).equals(JSON_MINUS_INFINITY)) {
 
                     if (parser.allowNaN) {
@@ -632,7 +656,7 @@ case 1:
             }
 	break;
 	case 6:
-// line 420 "Parser.rl"
+// line 444 "Parser.rl"
 	{
                 parseString(res, p, pe);
                 if (res.result == null) {
@@ -645,7 +669,7 @@ case 1:
             }
 	break;
 	case 7:
-// line 430 "Parser.rl"
+// line 454 "Parser.rl"
 	{
                 currentNesting++;
                 parseArray(res, p, pe);
@@ -660,7 +684,7 @@ case 1:
             }
 	break;
 	case 8:
-// line 442 "Parser.rl"
+// line 466 "Parser.rl"
 	{
                 currentNesting++;
                 parseObject(res, p, pe);
@@ -674,7 +698,7 @@ case 1:
                 }
             }
 	break;
-// line 678 "Parser.java"
+// line 702 "Parser.java"
 			}
 		}
 	}
@@ -694,7 +718,7 @@ case 5:
 	break; }
 	}
 
-// line 477 "Parser.rl"
+// line 501 "Parser.rl"
 
             if (cs >= JSON_value_first_final && result != null) {
                 res.update(result, p);
@@ -704,7 +728,7 @@ case 5:
         }
 
         
-// line 708 "Parser.java"
+// line 732 "Parser.java"
 private static byte[] init__JSON_integer_actions_0()
 {
 	return new byte [] {
@@ -803,7 +827,7 @@ static final int JSON_integer_error = 0;
 static final int JSON_integer_en_main = 1;
 
 
-// line 496 "Parser.rl"
+// line 520 "Parser.rl"
 
 
         void parseInteger(ParserResult res, int p, int pe) {
@@ -821,15 +845,15 @@ static final int JSON_integer_en_main = 1;
             int cs = EVIL;
 
             
-// line 825 "Parser.java"
+// line 849 "Parser.java"
 	{
 	cs = JSON_integer_start;
 	}
 
-// line 513 "Parser.rl"
+// line 537 "Parser.rl"
             int memo = p;
             
-// line 833 "Parser.java"
+// line 857 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -910,13 +934,13 @@ case 1:
 			switch ( _JSON_integer_actions[_acts++] )
 			{
 	case 0:
-// line 490 "Parser.rl"
+// line 514 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 920 "Parser.java"
+// line 944 "Parser.java"
 			}
 		}
 	}
@@ -936,7 +960,7 @@ case 5:
 	break; }
 	}
 
-// line 515 "Parser.rl"
+// line 539 "Parser.rl"
 
             if (cs < JSON_integer_first_final) {
                 return -1;
@@ -958,7 +982,7 @@ case 5:
         }
 
         
-// line 962 "Parser.java"
+// line 986 "Parser.java"
 private static byte[] init__JSON_float_actions_0()
 {
 	return new byte [] {
@@ -1060,7 +1084,7 @@ static final int JSON_float_error = 0;
 static final int JSON_float_en_main = 1;
 
 
-// line 550 "Parser.rl"
+// line 574 "Parser.rl"
 
 
         void parseFloat(ParserResult res, int p, int pe) {
@@ -1078,15 +1102,15 @@ static final int JSON_float_en_main = 1;
             int cs = EVIL;
 
             
-// line 1082 "Parser.java"
+// line 1106 "Parser.java"
 	{
 	cs = JSON_float_start;
 	}
 
-// line 567 "Parser.rl"
+// line 591 "Parser.rl"
             int memo = p;
             
-// line 1090 "Parser.java"
+// line 1114 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1167,13 +1191,13 @@ case 1:
 			switch ( _JSON_float_actions[_acts++] )
 			{
 	case 0:
-// line 541 "Parser.rl"
+// line 565 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1177 "Parser.java"
+// line 1201 "Parser.java"
 			}
 		}
 	}
@@ -1193,7 +1217,7 @@ case 5:
 	break; }
 	}
 
-// line 569 "Parser.rl"
+// line 593 "Parser.rl"
 
             if (cs < JSON_float_first_final) {
                 return -1;
@@ -1209,7 +1233,7 @@ case 5:
         }
 
         
-// line 1213 "Parser.java"
+// line 1237 "Parser.java"
 private static byte[] init__JSON_string_actions_0()
 {
 	return new byte [] {
@@ -1311,7 +1335,7 @@ static final int JSON_string_error = 0;
 static final int JSON_string_en_main = 1;
 
 
-// line 614 "Parser.rl"
+// line 638 "Parser.rl"
 
 
         void parseString(ParserResult res, int p, int pe) {
@@ -1319,15 +1343,15 @@ static final int JSON_string_en_main = 1;
             IRubyObject result = null;
 
             
-// line 1323 "Parser.java"
+// line 1347 "Parser.java"
 	{
 	cs = JSON_string_start;
 	}
 
-// line 621 "Parser.rl"
+// line 645 "Parser.rl"
             int memo = p;
             
-// line 1331 "Parser.java"
+// line 1355 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1408,7 +1432,7 @@ case 1:
 			switch ( _JSON_string_actions[_acts++] )
 			{
 	case 0:
-// line 589 "Parser.rl"
+// line 613 "Parser.rl"
 	{
                 int offset = byteList.begin();
                 ByteList decoded = decoder.decode(byteList, memo + 1 - offset,
@@ -1423,13 +1447,13 @@ case 1:
             }
 	break;
 	case 1:
-// line 602 "Parser.rl"
+// line 626 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1433 "Parser.java"
+// line 1457 "Parser.java"
 			}
 		}
 	}
@@ -1449,7 +1473,7 @@ case 5:
 	break; }
 	}
 
-// line 623 "Parser.rl"
+// line 647 "Parser.rl"
 
             if (parser.createAdditions) {
                 RubyHash match_string = parser.match_string;
@@ -1488,7 +1512,7 @@ case 5:
         }
 
         
-// line 1492 "Parser.java"
+// line 1516 "Parser.java"
 private static byte[] init__JSON_array_actions_0()
 {
 	return new byte [] {
@@ -1601,7 +1625,7 @@ static final int JSON_array_error = 0;
 static final int JSON_array_en_main = 1;
 
 
-// line 697 "Parser.rl"
+// line 721 "Parser.rl"
 
 
         void parseArray(ParserResult res, int p, int pe) {
@@ -1621,14 +1645,14 @@ static final int JSON_array_en_main = 1;
             }
 
             
-// line 1625 "Parser.java"
+// line 1649 "Parser.java"
 	{
 	cs = JSON_array_start;
 	}
 
-// line 716 "Parser.rl"
+// line 740 "Parser.rl"
             
-// line 1632 "Parser.java"
+// line 1656 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1709,7 +1733,7 @@ case 1:
 			switch ( _JSON_array_actions[_acts++] )
 			{
 	case 0:
-// line 666 "Parser.rl"
+// line 690 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -1726,13 +1750,13 @@ case 1:
             }
 	break;
 	case 1:
-// line 681 "Parser.rl"
+// line 705 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1736 "Parser.java"
+// line 1760 "Parser.java"
 			}
 		}
 	}
@@ -1752,7 +1776,7 @@ case 5:
 	break; }
 	}
 
-// line 717 "Parser.rl"
+// line 741 "Parser.rl"
 
             if (cs >= JSON_array_first_final) {
                 res.update(result, p + 1);
@@ -1762,7 +1786,7 @@ case 5:
         }
 
         
-// line 1766 "Parser.java"
+// line 1790 "Parser.java"
 private static byte[] init__JSON_object_actions_0()
 {
 	return new byte [] {
@@ -1885,7 +1909,7 @@ static final int JSON_object_error = 0;
 static final int JSON_object_en_main = 1;
 
 
-// line 776 "Parser.rl"
+// line 800 "Parser.rl"
 
 
         void parseObject(ParserResult res, int p, int pe) {
@@ -1910,14 +1934,14 @@ static final int JSON_object_en_main = 1;
             }
 
             
-// line 1914 "Parser.java"
+// line 1938 "Parser.java"
 	{
 	cs = JSON_object_start;
 	}
 
-// line 800 "Parser.rl"
+// line 824 "Parser.rl"
             
-// line 1921 "Parser.java"
+// line 1945 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1998,7 +2022,7 @@ case 1:
 			switch ( _JSON_object_actions[_acts++] )
 			{
 	case 0:
-// line 731 "Parser.rl"
+// line 755 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -2015,7 +2039,7 @@ case 1:
             }
 	break;
 	case 1:
-// line 746 "Parser.rl"
+// line 770 "Parser.rl"
 	{
                 parseString(res, p, pe);
                 if (res.result == null) {
@@ -2035,13 +2059,13 @@ case 1:
             }
 	break;
 	case 2:
-// line 764 "Parser.rl"
+// line 788 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 2045 "Parser.java"
+// line 2069 "Parser.java"
 			}
 		}
 	}
@@ -2061,7 +2085,7 @@ case 5:
 	break; }
 	}
 
-// line 801 "Parser.rl"
+// line 825 "Parser.rl"
 
             if (cs < JSON_object_first_final) {
                 res.update(null, p + 1);
@@ -2094,7 +2118,7 @@ case 5:
         }
 
         
-// line 2098 "Parser.java"
+// line 2122 "Parser.java"
 private static byte[] init__JSON_actions_0()
 {
 	return new byte [] {
@@ -2198,7 +2222,7 @@ static final int JSON_error = 0;
 static final int JSON_en_main = 1;
 
 
-// line 866 "Parser.rl"
+// line 890 "Parser.rl"
 
 
         public IRubyObject parseStrict() {
@@ -2208,16 +2232,16 @@ static final int JSON_en_main = 1;
             ParserResult res = new ParserResult();
 
             
-// line 2212 "Parser.java"
+// line 2236 "Parser.java"
 	{
 	cs = JSON_start;
 	}
 
-// line 875 "Parser.rl"
+// line 899 "Parser.rl"
             p = byteList.begin();
             pe = p + byteList.length();
             
-// line 2221 "Parser.java"
+// line 2245 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -2298,7 +2322,7 @@ case 1:
 			switch ( _JSON_actions[_acts++] )
 			{
 	case 0:
-// line 838 "Parser.rl"
+// line 862 "Parser.rl"
 	{
                 currentNesting = 1;
                 parseObject(res, p, pe);
@@ -2312,7 +2336,7 @@ case 1:
             }
 	break;
 	case 1:
-// line 850 "Parser.rl"
+// line 874 "Parser.rl"
 	{
                 currentNesting = 1;
                 parseArray(res, p, pe);
@@ -2325,7 +2349,7 @@ case 1:
                 }
             }
 	break;
-// line 2329 "Parser.java"
+// line 2353 "Parser.java"
 			}
 		}
 	}
@@ -2345,7 +2369,7 @@ case 5:
 	break; }
 	}
 
-// line 878 "Parser.rl"
+// line 902 "Parser.rl"
 
             if (cs >= JSON_first_final && p == pe) {
                 return result;
@@ -2355,28 +2379,28 @@ case 5:
         }
 
         
-// line 2359 "Parser.java"
-private static byte[] init__JSON_quirks_mode_actions_0()
+// line 2383 "Parser.java"
+private static byte[] init__JSON_text_actions_0()
 {
 	return new byte [] {
 	    0,    1,    0
 	};
 }
 
-private static final byte _JSON_quirks_mode_actions[] = init__JSON_quirks_mode_actions_0();
+private static final byte _JSON_text_actions[] = init__JSON_text_actions_0();
 
 
-private static byte[] init__JSON_quirks_mode_key_offsets_0()
+private static byte[] init__JSON_text_key_offsets_0()
 {
 	return new byte [] {
 	    0,    0,   16,   18,   19,   21,   22,   24,   25,   27,   28
 	};
 }
 
-private static final byte _JSON_quirks_mode_key_offsets[] = init__JSON_quirks_mode_key_offsets_0();
+private static final byte _JSON_text_key_offsets[] = init__JSON_text_key_offsets_0();
 
 
-private static char[] init__JSON_quirks_mode_trans_keys_0()
+private static char[] init__JSON_text_trans_keys_0()
 {
 	return new char [] {
 	   13,   32,   34,   45,   47,   73,   78,   91,  102,  110,  116,  123,
@@ -2385,40 +2409,40 @@ private static char[] init__JSON_quirks_mode_trans_keys_0()
 	};
 }
 
-private static final char _JSON_quirks_mode_trans_keys[] = init__JSON_quirks_mode_trans_keys_0();
+private static final char _JSON_text_trans_keys[] = init__JSON_text_trans_keys_0();
 
 
-private static byte[] init__JSON_quirks_mode_single_lengths_0()
+private static byte[] init__JSON_text_single_lengths_0()
 {
 	return new byte [] {
 	    0,   12,    2,    1,    2,    1,    2,    1,    2,    1,    3
 	};
 }
 
-private static final byte _JSON_quirks_mode_single_lengths[] = init__JSON_quirks_mode_single_lengths_0();
+private static final byte _JSON_text_single_lengths[] = init__JSON_text_single_lengths_0();
 
 
-private static byte[] init__JSON_quirks_mode_range_lengths_0()
+private static byte[] init__JSON_text_range_lengths_0()
 {
 	return new byte [] {
 	    0,    2,    0,    0,    0,    0,    0,    0,    0,    0,    1
 	};
 }
 
-private static final byte _JSON_quirks_mode_range_lengths[] = init__JSON_quirks_mode_range_lengths_0();
+private static final byte _JSON_text_range_lengths[] = init__JSON_text_range_lengths_0();
 
 
-private static byte[] init__JSON_quirks_mode_index_offsets_0()
+private static byte[] init__JSON_text_index_offsets_0()
 {
 	return new byte [] {
 	    0,    0,   15,   18,   20,   23,   25,   28,   30,   33,   35
 	};
 }
 
-private static final byte _JSON_quirks_mode_index_offsets[] = init__JSON_quirks_mode_index_offsets_0();
+private static final byte _JSON_text_index_offsets[] = init__JSON_text_index_offsets_0();
 
 
-private static byte[] init__JSON_quirks_mode_indicies_0()
+private static byte[] init__JSON_text_indicies_0()
 {
 	return new byte [] {
 	    0,    0,    2,    2,    3,    2,    2,    2,    2,    2,    2,    2,
@@ -2428,56 +2452,56 @@ private static byte[] init__JSON_quirks_mode_indicies_0()
 	};
 }
 
-private static final byte _JSON_quirks_mode_indicies[] = init__JSON_quirks_mode_indicies_0();
+private static final byte _JSON_text_indicies[] = init__JSON_text_indicies_0();
 
 
-private static byte[] init__JSON_quirks_mode_trans_targs_0()
+private static byte[] init__JSON_text_trans_targs_0()
 {
 	return new byte [] {
 	    1,    0,   10,    6,    3,    5,    4,   10,    7,    9,    8,    2
 	};
 }
 
-private static final byte _JSON_quirks_mode_trans_targs[] = init__JSON_quirks_mode_trans_targs_0();
+private static final byte _JSON_text_trans_targs[] = init__JSON_text_trans_targs_0();
 
 
-private static byte[] init__JSON_quirks_mode_trans_actions_0()
+private static byte[] init__JSON_text_trans_actions_0()
 {
 	return new byte [] {
 	    0,    0,    1,    0,    0,    0,    0,    0,    0,    0,    0,    0
 	};
 }
 
-private static final byte _JSON_quirks_mode_trans_actions[] = init__JSON_quirks_mode_trans_actions_0();
+private static final byte _JSON_text_trans_actions[] = init__JSON_text_trans_actions_0();
 
 
-static final int JSON_quirks_mode_start = 1;
-static final int JSON_quirks_mode_first_final = 10;
-static final int JSON_quirks_mode_error = 0;
+static final int JSON_text_start = 1;
+static final int JSON_text_first_final = 10;
+static final int JSON_text_error = 0;
 
-static final int JSON_quirks_mode_en_main = 1;
-
-
-// line 906 "Parser.rl"
+static final int JSON_text_en_main = 1;
 
 
-        public IRubyObject parseQuirksMode() {
+// line 930 "Parser.rl"
+
+
+        public IRubyObject parseJsonText() {
             int cs = EVIL;
             int p, pe;
             IRubyObject result = null;
             ParserResult res = new ParserResult();
 
             
-// line 2472 "Parser.java"
+// line 2496 "Parser.java"
 	{
-	cs = JSON_quirks_mode_start;
+	cs = JSON_text_start;
 	}
 
-// line 915 "Parser.rl"
+// line 939 "Parser.rl"
             p = byteList.begin();
             pe = p + byteList.length();
             
-// line 2481 "Parser.java"
+// line 2505 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -2499,9 +2523,9 @@ static final int JSON_quirks_mode_en_main = 1;
 	}
 case 1:
 	_match: do {
-	_keys = _JSON_quirks_mode_key_offsets[cs];
-	_trans = _JSON_quirks_mode_index_offsets[cs];
-	_klen = _JSON_quirks_mode_single_lengths[cs];
+	_keys = _JSON_text_key_offsets[cs];
+	_trans = _JSON_text_index_offsets[cs];
+	_klen = _JSON_text_single_lengths[cs];
 	if ( _klen > 0 ) {
 		int _lower = _keys;
 		int _mid;
@@ -2511,9 +2535,9 @@ case 1:
 				break;
 
 			_mid = _lower + ((_upper-_lower) >> 1);
-			if ( data[p] < _JSON_quirks_mode_trans_keys[_mid] )
+			if ( data[p] < _JSON_text_trans_keys[_mid] )
 				_upper = _mid - 1;
-			else if ( data[p] > _JSON_quirks_mode_trans_keys[_mid] )
+			else if ( data[p] > _JSON_text_trans_keys[_mid] )
 				_lower = _mid + 1;
 			else {
 				_trans += (_mid - _keys);
@@ -2524,7 +2548,7 @@ case 1:
 		_trans += _klen;
 	}
 
-	_klen = _JSON_quirks_mode_range_lengths[cs];
+	_klen = _JSON_text_range_lengths[cs];
 	if ( _klen > 0 ) {
 		int _lower = _keys;
 		int _mid;
@@ -2534,9 +2558,9 @@ case 1:
 				break;
 
 			_mid = _lower + (((_upper-_lower) >> 1) & ~1);
-			if ( data[p] < _JSON_quirks_mode_trans_keys[_mid] )
+			if ( data[p] < _JSON_text_trans_keys[_mid] )
 				_upper = _mid - 2;
-			else if ( data[p] > _JSON_quirks_mode_trans_keys[_mid+1] )
+			else if ( data[p] > _JSON_text_trans_keys[_mid+1] )
 				_lower = _mid + 2;
 			else {
 				_trans += ((_mid - _keys)>>1);
@@ -2547,18 +2571,18 @@ case 1:
 	}
 	} while (false);
 
-	_trans = _JSON_quirks_mode_indicies[_trans];
-	cs = _JSON_quirks_mode_trans_targs[_trans];
+	_trans = _JSON_text_indicies[_trans];
+	cs = _JSON_text_trans_targs[_trans];
 
-	if ( _JSON_quirks_mode_trans_actions[_trans] != 0 ) {
-		_acts = _JSON_quirks_mode_trans_actions[_trans];
-		_nacts = (int) _JSON_quirks_mode_actions[_acts++];
+	if ( _JSON_text_trans_actions[_trans] != 0 ) {
+		_acts = _JSON_text_trans_actions[_trans];
+		_nacts = (int) _JSON_text_actions[_acts++];
 		while ( _nacts-- > 0 )
 	{
-			switch ( _JSON_quirks_mode_actions[_acts++] )
+			switch ( _JSON_text_actions[_acts++] )
 			{
 	case 0:
-// line 892 "Parser.rl"
+// line 916 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -2570,7 +2594,7 @@ case 1:
                 }
             }
 	break;
-// line 2574 "Parser.java"
+// line 2598 "Parser.java"
 			}
 		}
 	}
@@ -2590,9 +2614,9 @@ case 5:
 	break; }
 	}
 
-// line 918 "Parser.rl"
+// line 942 "Parser.rl"
 
-            if (cs >= JSON_quirks_mode_first_final && p == pe) {
+            if (cs >= JSON_text_first_final && p == pe) {
                 return result;
             } else {
                 throw unexpectedToken(p, pe);
@@ -2600,8 +2624,8 @@ case 5:
         }
 
         public IRubyObject parse() {
-          if (parser.quirksMode) {
-            return parseQuirksMode();
+          if (parser.quirksMode || parser.standardsMode) {
+            return parseJsonText();
           } else {
             return parseStrict();
           }

--- a/java/src/json/ext/Parser.java
+++ b/java/src/json/ext/Parser.java
@@ -130,7 +130,7 @@ public class Parser extends RubyObject {
      * 
      * <dt><code>:create_additions</code>
      * <dd>If set to <code>false</code>, the Parser doesn't create additions
-     * even if a matchin class and <code>create_id</code> was found. This option
+     * even if a matching class and <code>create_id</code> was found. This option
      * defaults to <code>true</code>.
      *
      * <dt><code>:object_class</code>

--- a/java/src/json/ext/Utils.java
+++ b/java/src/json/ext/Utils.java
@@ -24,6 +24,7 @@ import org.jruby.util.ByteList;
 final class Utils {
     public static final String M_GENERATOR_ERROR = "GeneratorError";
     public static final String M_NESTING_ERROR = "NestingError";
+    public static final String M_ENCODING_ERROR = "EncodingError";
     public static final String M_PARSER_ERROR = "ParserError";
 
     private Utils() {

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -114,6 +114,9 @@ module JSON
   # This exception is raised if a parser error occurs.
   class ParserError < JSONError; end
 
+  # This exception is raised if the data cannot be encoded into the correct format
+  class EncodingError < ParserError; end
+
   # This exception is raised if the nesting of parsed data structures is too
   # deep.
   class NestingError < ParserError; end

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -296,12 +296,14 @@ module JSON
     #  :max_nesting: false
     #  :allow_nan:   true
     #  :quirks_mode: true
+    #  :standards_mode: false
     attr_accessor :load_default_options
   end
   self.load_default_options = {
     :max_nesting      => false,
     :allow_nan        => true,
     :quirks_mode      => true,
+    :standards_mode   => false,
     :create_additions => true,
   }
 
@@ -358,12 +360,14 @@ module JSON
     #  :max_nesting: false
     #  :allow_nan:   true
     #  :quirks_mode: true
+    #  :standards_mode: false
     attr_accessor :dump_default_options
   end
   self.dump_default_options = {
     :max_nesting => false,
     :allow_nan   => true,
     :quirks_mode => true,
+    :standards_mode => false,
   }
 
   # Dumps _obj_ as a JSON string, i.e. calls generate on the object and returns

--- a/lib/json/pure/generator.rb
+++ b/lib/json/pure/generator.rb
@@ -156,6 +156,8 @@ module JSON
         #   encountered. This options defaults to false.
         # * *quirks_mode*: Enables quirks_mode for parser, that is for example
         #   generating single JSON values instead of documents is possible.
+        # * *standards_mode*: Enables JSON parsing according to rfc7159 (rather
+        #   than rfc4627 which is the default)
         def initialize(opts = {})
           @indent                = ''
           @space                 = ''
@@ -165,6 +167,7 @@ module JSON
           @allow_nan             = false
           @ascii_only            = false
           @quirks_mode           = false
+          @standards_mode        = false
           @buffer_initial_length = 1024
           configure opts
         end
@@ -193,6 +196,10 @@ module JSON
         # If this attribute is set to true, quirks mode is enabled, otherwise
         # it's disabled.
         attr_accessor :quirks_mode
+
+        # This attribute is true if rfc 7159 standards mode is enabled,
+        # otherwise it's disabled
+        attr_accessor :standards_mode
 
         # :stopdoc:
         attr_reader :buffer_initial_length
@@ -238,6 +245,11 @@ module JSON
           @quirks_mode
         end
 
+        # Returns true, if rfc7159 standards mode is enabled. Otherwise returns false.
+        def standards_mode?
+          @standards_mode
+        end
+
         # Configure this State instance with the Hash _opts_, and return
         # itself.
         def configure(opts)
@@ -260,6 +272,7 @@ module JSON
           @ascii_only            = opts[:ascii_only] if opts.key?(:ascii_only)
           @depth                 = opts[:depth] || 0
           @quirks_mode           = opts[:quirks_mode] if opts.key?(:quirks_mode)
+          @standards_mode        = opts[:standards_mode] if opts.key?(:standards_mode)
           @buffer_initial_length ||= opts[:buffer_initial_length]
 
           if !opts.key?(:max_nesting) # defaults to 100
@@ -293,7 +306,7 @@ module JSON
           result = obj.to_json(self)
           JSON.valid_utf8?(result) or raise GeneratorError,
             "source sequence #{result.inspect} is illegal/malformed utf-8"
-          unless @quirks_mode
+          unless @quirks_mode || @standards_mode
             unless result =~ /\A\s*\[/ && result =~ /\]\s*\Z/ ||
               result =~ /\A\s*\{/ && result =~ /\}\s*\Z/
             then

--- a/lib/json/pure/parser.rb
+++ b/lib/json/pure/parser.rb
@@ -74,6 +74,7 @@ module JSON
       #   than rfc4627 which is the default)
       def initialize(source, opts = {})
         opts ||= {}
+        @standards_mode = opts[:standards_mode]
         unless @quirks_mode = opts[:quirks_mode]
           source = convert_encoding source
         end
@@ -96,7 +97,6 @@ module JSON
         @object_class = opts[:object_class] || Hash
         @array_class  = opts[:array_class] || Array
         @match_string = opts[:match_string]
-        @standards_mode = opts[:standards_mode]
       end
 
       alias source string
@@ -157,6 +157,11 @@ module JSON
           source = source.to_str
         else
           raise TypeError, "#{source.inspect} is not like a string"
+        end
+        if @standards_mode
+          raise EncodingError, "A JSON text must at least contain one octet!" if source.length < 1
+        else
+          raise EncodingError, "A JSON text must at least contain two octets!" if source.length < 2
         end
         if defined?(::Encoding)
           if source.encoding == ::Encoding::ASCII_8BIT

--- a/lib/json/pure/parser.rb
+++ b/lib/json/pure/parser.rb
@@ -70,6 +70,8 @@ module JSON
       # * *array_class*: Defaults to Array
       # * *quirks_mode*: Enables quirks_mode for parser, that is for example
       #   parsing single JSON values instead of documents is possible.
+      # * *standards_mode*: Enables JSON parsing according to rfc7159 (rather
+      #   than rfc4627 which is the default)
       def initialize(source, opts = {})
         opts ||= {}
         unless @quirks_mode = opts[:quirks_mode]
@@ -94,12 +96,17 @@ module JSON
         @object_class = opts[:object_class] || Hash
         @array_class  = opts[:array_class] || Array
         @match_string = opts[:match_string]
+        @standards_mode = opts[:standards_mode]
       end
 
       alias source string
 
       def quirks_mode?
         !!@quirks_mode
+      end
+
+      def standards_mode?
+        !!@standards_mode
       end
 
       def reset
@@ -112,7 +119,7 @@ module JSON
       def parse
         reset
         obj = nil
-        if @quirks_mode
+        if @quirks_mode || @standards_mode
           while !eos? && skip(IGNORE)
           end
           if eos?

--- a/tests/test_json.rb
+++ b/tests/test_json.rb
@@ -107,9 +107,9 @@ class TestJSON < Test::Unit::TestCase
   end
 
   def test_parse_json_primitive_values
-    assert_raise(JSON::ParserError) { JSON.parse('') }
+    assert_raise(JSON::EncodingError) { JSON.parse('') }
     assert_raise(JSON::ParserError) { JSON.parse('', :quirks_mode => true) }
-    assert_raise(JSON::ParserError) { JSON.parse('', :standards_mode => true) }
+    assert_raise(JSON::EncodingError) { JSON.parse('', :standards_mode => true) }
     assert_raise(TypeError) { JSON::Parser.new(nil).parse }
     assert_raise(TypeError) { JSON::Parser.new(nil, :quirks_mode => true).parse }
     assert_raise(TypeError) { JSON::Parser.new(nil, :standards_mode => true).parse }
@@ -143,7 +143,7 @@ class TestJSON < Test::Unit::TestCase
     assert_raise(JSON::ParserError) { JSON.parse('23') }
     assert_equal 23, JSON.parse('23', :quirks_mode => true)
     assert_equal 23, JSON.parse('23', :standards_mode => true)
-    assert_raise(JSON::ParserError) { JSON.parse('1') }
+    assert_raise(JSON::EncodingError) { JSON.parse('1') }
     assert_equal 1, JSON.parse('1', :quirks_mode => true)
     assert_equal 1, JSON.parse('1', :standards_mode => true)
     assert_raise(JSON::ParserError) { JSON.parse('3.141') }

--- a/tests/test_json.rb
+++ b/tests/test_json.rb
@@ -109,41 +109,69 @@ class TestJSON < Test::Unit::TestCase
   def test_parse_json_primitive_values
     assert_raise(JSON::ParserError) { JSON.parse('') }
     assert_raise(JSON::ParserError) { JSON.parse('', :quirks_mode => true) }
+    assert_raise(JSON::ParserError) { JSON.parse('', :standards_mode => true) }
     assert_raise(TypeError) { JSON::Parser.new(nil).parse }
     assert_raise(TypeError) { JSON::Parser.new(nil, :quirks_mode => true).parse }
+    assert_raise(TypeError) { JSON::Parser.new(nil, :standards_mode => true).parse }
     assert_raise(TypeError) { JSON.parse(nil) }
     assert_raise(TypeError) { JSON.parse(nil, :quirks_mode => true) }
+    assert_raise(TypeError) { JSON.parse(nil, :standards_mode => true) }
     assert_raise(JSON::ParserError) { JSON.parse('  /* foo */ ') }
     assert_raise(JSON::ParserError) { JSON.parse('  /* foo */ ', :quirks_mode => true) }
+    assert_raise(JSON::ParserError) { JSON.parse('  /* foo */ ', :standards_mode => true) }
     parser = JSON::Parser.new('null')
     assert_equal false, parser.quirks_mode?
+    assert_equal false, parser.standards_mode?
     assert_raise(JSON::ParserError) { parser.parse }
-    assert_raise(JSON::ParserError) { JSON.parse('null') }
-    assert_equal nil, JSON.parse('null', :quirks_mode => true)
     parser = JSON::Parser.new('null', :quirks_mode => true)
     assert_equal true, parser.quirks_mode?
+    assert_equal false, parser.standards_mode?
     assert_equal nil, parser.parse
+    parser = JSON::Parser.new('null', :standards_mode => true)
+    assert_equal false, parser.quirks_mode?
+    assert_equal true, parser.standards_mode?
+    assert_equal nil, parser.parse
+    assert_raise(JSON::ParserError) { JSON.parse('null') }
+    assert_equal nil, JSON.parse('null', :quirks_mode => true)
+    assert_equal nil, JSON.parse('null', :standards_mode => true)
     assert_raise(JSON::ParserError) { JSON.parse('false') }
     assert_equal false, JSON.parse('false', :quirks_mode => true)
+    assert_equal false, JSON.parse('false', :standards_mode => true)
     assert_raise(JSON::ParserError) { JSON.parse('true') }
     assert_equal true, JSON.parse('true', :quirks_mode => true)
+    assert_equal true, JSON.parse('true', :standards_mode => true)
     assert_raise(JSON::ParserError) { JSON.parse('23') }
     assert_equal 23, JSON.parse('23', :quirks_mode => true)
+    assert_equal 23, JSON.parse('23', :standards_mode => true)
     assert_raise(JSON::ParserError) { JSON.parse('1') }
     assert_equal 1, JSON.parse('1', :quirks_mode => true)
+    assert_equal 1, JSON.parse('1', :standards_mode => true)
     assert_raise(JSON::ParserError) { JSON.parse('3.141') }
     assert_in_delta 3.141, JSON.parse('3.141', :quirks_mode => true), 1E-3
+    assert_in_delta 3.141, JSON.parse('3.141', :standards_mode => true), 1E-3
     assert_raise(JSON::ParserError) { JSON.parse('18446744073709551616') }
     assert_equal 2 ** 64, JSON.parse('18446744073709551616', :quirks_mode => true)
+    assert_equal 2 ** 64, JSON.parse('18446744073709551616', :standards_mode => true)
+    assert_raise(JSON::ParserError) { JSON.parse('5e10') }
+    assert_equal 5e10, JSON.parse('5e10', :quirks_mode => true)
+    assert_equal 5e10, JSON.parse('5e10', :standards_mode => true)
     assert_raise(JSON::ParserError) { JSON.parse('"foo"') }
     assert_equal 'foo', JSON.parse('"foo"', :quirks_mode => true)
+    assert_equal 'foo', JSON.parse('"foo"', :standards_mode => true)
     assert_raise(JSON::ParserError) { JSON.parse('NaN', :allow_nan => true) }
     assert JSON.parse('NaN', :quirks_mode => true, :allow_nan => true).nan?
+    assert JSON.parse('NaN', :standards_mode => true, :allow_nan => true).nan?
     assert_raise(JSON::ParserError) { JSON.parse('Infinity', :allow_nan => true) }
     assert JSON.parse('Infinity', :quirks_mode => true, :allow_nan => true).infinite?
+    assert JSON.parse('Infinity', :standards_mode => true, :allow_nan => true).infinite?
     assert_raise(JSON::ParserError) { JSON.parse('-Infinity', :allow_nan => true) }
     assert JSON.parse('-Infinity', :quirks_mode => true, :allow_nan => true).infinite?
+    assert JSON.parse('-Infinity', :standards_mode => true, :allow_nan => true).infinite?
     assert_raise(JSON::ParserError) { JSON.parse('[ 1, ]', :quirks_mode => true) }
+    assert_raise(JSON::ParserError) { JSON.parse('[ 1, ]', :standards_mode => true) }
+    assert_raise(JSON::ParserError) { JSON.parse('NaN', :standards_mode => true) }
+    assert_raise(JSON::ParserError) { JSON.parse('Infinity', :standards_mode => true) }
+    assert_raise(JSON::ParserError) { JSON.parse('-Infinity', :standards_mode => true) }
   end
 
   if Array.method_defined?(:permutation)

--- a/tests/test_json_generate.rb
+++ b/tests/test_json_generate.rb
@@ -53,6 +53,7 @@ EOT
     assert_equal({"1"=>2}, parsed_json)
     assert_raise(GeneratorError) { generate(666) }
     assert_equal '666', generate(666, :quirks_mode => true)
+    assert_equal '666', generate(666, :standards_mode => true)
   end
 
   def test_generate_pretty
@@ -71,6 +72,7 @@ EOT
     assert_equal({"1"=>2}, parsed_json)
     assert_raise(GeneratorError) { pretty_generate(666) }
     assert_equal '666', pretty_generate(666, :quirks_mode => true)
+    assert_equal '666', pretty_generate(666, :standards_mode => true)
   end
 
   def test_fast_generate
@@ -84,6 +86,7 @@ EOT
     assert_equal({"1"=>2}, parsed_json)
     assert_raise(GeneratorError) { fast_generate(666) }
     assert_equal '666', fast_generate(666, :quirks_mode => true)
+    assert_equal '666', fast_generate(666, :standards_mode => true)
   end
 
   def test_own_state
@@ -99,6 +102,9 @@ EOT
     assert_raise(GeneratorError) { generate(666, state) }
     state.quirks_mode = true
     assert state.quirks_mode?
+    assert_equal '666', generate(666, state)
+    state.standards_mode = true
+    assert state.standards_mode?
     assert_equal '666', generate(666, state)
   end
 
@@ -128,6 +134,7 @@ EOT
       :ascii_only            => false,
       :buffer_initial_length => 1024,
       :quirks_mode           => false,
+      :standards_mode        => false,
       :depth                 => 0,
       :indent                => "  ",
       :max_nesting           => 100,
@@ -145,6 +152,7 @@ EOT
       :ascii_only            => false,
       :buffer_initial_length => 1024,
       :quirks_mode           => false,
+      :standards_mode        => false,
       :depth                 => 0,
       :indent                => "",
       :max_nesting           => 100,
@@ -162,6 +170,7 @@ EOT
       :ascii_only            => false,
       :buffer_initial_length => 1024,
       :quirks_mode           => false,
+      :standards_mode        => false,
       :depth                 => 0,
       :indent                => "",
       :max_nesting           => 0,


### PR DESCRIPTION
This adds a new "mode" to JSON which parse/generates JSON according to RFC7159 (the most up-to-date JSON spec), a fix for #206. The main difference between RFC4627 (the default in the JSON gem) and RFC7159 is that the latter RFC accepts JSON values as a valid JSON text.

You can use the new mode by passing `standards_mode: true` to `parse` (in a similar way to how `quirks_mode` is activated).