### PR TITLE
Allow ruby-head builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ matrix:
   allow_failures:
     - rvm: rbx-18mode
     - rvm: rbx-19mode
+    - rvm: ruby-head
 script: "bundle exec rake"


### PR DESCRIPTION
This is probably a contraversial idea. ruby-head can be fairly unstable, and this can make builds fail (fairly) arbitrarily. I appreciate that json is a core ruby gem but right now it's hard to tell if there are issues with a pull request or master because of ruby-head. At least if it's an allowed-failure then builds will always be run against ruby-head, but there won't be "false positive" build failures if something is broken in ruby-head (or changed in a way that never makes it to a release).
