### PR TITLE
Add Parsing Option that Specifies Class for Decimals

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -80,15 +80,16 @@ static VALUE CNaN, CInfinity, CMinusInfinity;
 
 static ID i_json_creatable_p, i_json_create, i_create_id, i_create_additions,
           i_chr, i_max_nesting, i_allow_nan, i_symbolize_names, i_quirks_mode,
-          i_object_class, i_array_class, i_key_p, i_deep_const_get, i_match,
-          i_match_string, i_aset, i_aref, i_leftshift;
+          i_object_class, i_array_class, i_decimal_class, i_key_p,
+          i_deep_const_get, i_match, i_match_string, i_aset, i_aref,
+          i_leftshift, i_new;
 
 
-#line 110 "parser.rl"
+#line 111 "parser.rl"
 
 
 
-#line 92 "parser.c"
+#line 93 "parser.c"
 static const int JSON_object_start = 1;
 static const int JSON_object_first_final = 27;
 static const int JSON_object_error = 0;
@@ -96,7 +97,7 @@ static const int JSON_object_error = 0;
 static const int JSON_object_en_main = 1;
 
 
-#line 151 "parser.rl"
+#line 152 "parser.rl"
 
 
 static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -112,14 +113,14 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
     *result = NIL_P(object_class) ? rb_hash_new() : rb_class_new_instance(0, 0, object_class);
 
 
-#line 116 "parser.c"
+#line 117 "parser.c"
 	{
 	cs = JSON_object_start;
 	}
 
-#line 166 "parser.rl"
+#line 167 "parser.rl"
 
-#line 123 "parser.c"
+#line 124 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -147,7 +148,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 133 "parser.rl"
+#line 134 "parser.rl"
 	{
         char *np;
         json->parsing_name = 1;
@@ -160,7 +161,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 164 "parser.c"
+#line 165 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st3;
 		case 32: goto st3;
@@ -227,7 +228,7 @@ case 8:
 		goto st8;
 	goto st0;
 tr11:
-#line 118 "parser.rl"
+#line 119 "parser.rl"
 	{
         VALUE v = Qnil;
         char *np = JSON_parse_value(json, p, pe, &v);
@@ -247,7 +248,7 @@ st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 251 "parser.c"
+#line 252 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st9;
 		case 32: goto st9;
@@ -336,14 +337,14 @@ case 18:
 		goto st9;
 	goto st18;
 tr4:
-#line 141 "parser.rl"
+#line 142 "parser.rl"
 	{ p--; {p++; cs = 27; goto _out;} }
 	goto st27;
 st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 347 "parser.c"
+#line 348 "parser.c"
 	goto st0;
 st19:
 	if ( ++p == pe )
@@ -441,7 +442,7 @@ case 26:
 	_out: {}
 	}
 
-#line 167 "parser.rl"
+#line 168 "parser.rl"
 
     if (cs >= JSON_object_first_final) {
         if (json->create_additions) {
@@ -466,7 +467,7 @@ case 26:
 
 
 
-#line 470 "parser.c"
+#line 471 "parser.c"
 static const int JSON_value_start = 1;
 static const int JSON_value_first_final = 21;
 static const int JSON_value_error = 0;
@@ -474,7 +475,7 @@ static const int JSON_value_error = 0;
 static const int JSON_value_en_main = 1;
 
 
-#line 271 "parser.rl"
+#line 272 "parser.rl"
 
 
 static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -482,14 +483,14 @@ static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 486 "parser.c"
+#line 487 "parser.c"
 	{
 	cs = JSON_value_start;
 	}
 
-#line 278 "parser.rl"
+#line 279 "parser.rl"
 
-#line 493 "parser.c"
+#line 494 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -514,14 +515,14 @@ st0:
 cs = 0;
 	goto _out;
 tr0:
-#line 219 "parser.rl"
+#line 220 "parser.rl"
 	{
         char *np = JSON_parse_string(json, p, pe, result);
         if (np == NULL) { p--; {p++; cs = 21; goto _out;} } else {p = (( np))-1;}
     }
 	goto st21;
 tr2:
-#line 224 "parser.rl"
+#line 225 "parser.rl"
 	{
         char *np;
         if(pe > p + 9 - json->quirks_mode && !strncmp(MinusInfinity, p, 9)) {
@@ -541,7 +542,7 @@ tr2:
     }
 	goto st21;
 tr5:
-#line 242 "parser.rl"
+#line 243 "parser.rl"
 	{
         char *np;
         json->current_nesting++;
@@ -551,7 +552,7 @@ tr5:
     }
 	goto st21;
 tr9:
-#line 250 "parser.rl"
+#line 251 "parser.rl"
 	{
         char *np;
         json->current_nesting++;
@@ -561,7 +562,7 @@ tr9:
     }
 	goto st21;
 tr16:
-#line 212 "parser.rl"
+#line 213 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CInfinity;
@@ -571,7 +572,7 @@ tr16:
     }
 	goto st21;
 tr18:
-#line 205 "parser.rl"
+#line 206 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CNaN;
@@ -581,19 +582,19 @@ tr18:
     }
 	goto st21;
 tr22:
-#line 199 "parser.rl"
+#line 200 "parser.rl"
 	{
         *result = Qfalse;
     }
 	goto st21;
 tr25:
-#line 196 "parser.rl"
+#line 197 "parser.rl"
 	{
         *result = Qnil;
     }
 	goto st21;
 tr28:
-#line 202 "parser.rl"
+#line 203 "parser.rl"
 	{
         *result = Qtrue;
     }
@@ -602,9 +603,9 @@ st21:
 	if ( ++p == pe )
 		goto _test_eof21;
 case 21:
-#line 258 "parser.rl"
+#line 259 "parser.rl"
 	{ p--; {p++; cs = 21; goto _out;} }
-#line 608 "parser.c"
+#line 609 "parser.c"
 	goto st0;
 st2:
 	if ( ++p == pe )
@@ -765,7 +766,7 @@ case 20:
 	_out: {}
 	}
 
-#line 279 "parser.rl"
+#line 280 "parser.rl"
 
     if (cs >= JSON_value_first_final) {
         return p;
@@ -775,7 +776,7 @@ case 20:
 }
 
 
-#line 779 "parser.c"
+#line 780 "parser.c"
 static const int JSON_integer_start = 1;
 static const int JSON_integer_first_final = 3;
 static const int JSON_integer_error = 0;
@@ -783,7 +784,7 @@ static const int JSON_integer_error = 0;
 static const int JSON_integer_en_main = 1;
 
 
-#line 295 "parser.rl"
+#line 296 "parser.rl"
 
 
 static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -791,15 +792,15 @@ static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *res
     int cs = EVIL;
 
 
-#line 795 "parser.c"
+#line 796 "parser.c"
 	{
 	cs = JSON_integer_start;
 	}
 
-#line 302 "parser.rl"
+#line 303 "parser.rl"
     json->memo = p;
 
-#line 803 "parser.c"
+#line 804 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -833,14 +834,14 @@ case 3:
 		goto st0;
 	goto tr4;
 tr4:
-#line 292 "parser.rl"
+#line 293 "parser.rl"
 	{ p--; {p++; cs = 4; goto _out;} }
 	goto st4;
 st4:
 	if ( ++p == pe )
 		goto _test_eof4;
 case 4:
-#line 844 "parser.c"
+#line 845 "parser.c"
 	goto st0;
 st5:
 	if ( ++p == pe )
@@ -859,7 +860,7 @@ case 5:
 	_out: {}
 	}
 
-#line 304 "parser.rl"
+#line 305 "parser.rl"
 
     if (cs >= JSON_integer_first_final) {
         long len = p - json->memo;
@@ -874,7 +875,7 @@ case 5:
 }
 
 
-#line 878 "parser.c"
+#line 879 "parser.c"
 static const int JSON_float_start = 1;
 static const int JSON_float_first_final = 8;
 static const int JSON_float_error = 0;
@@ -882,7 +883,7 @@ static const int JSON_float_error = 0;
 static const int JSON_float_en_main = 1;
 
 
-#line 329 "parser.rl"
+#line 330 "parser.rl"
 
 
 static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -890,15 +891,15 @@ static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 894 "parser.c"
+#line 895 "parser.c"
 	{
 	cs = JSON_float_start;
 	}
 
-#line 336 "parser.rl"
+#line 337 "parser.rl"
     json->memo = p;
 
-#line 902 "parser.c"
+#line 903 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -956,14 +957,14 @@ case 8:
 		goto st0;
 	goto tr9;
 tr9:
-#line 323 "parser.rl"
+#line 324 "parser.rl"
 	{ p--; {p++; cs = 9; goto _out;} }
 	goto st9;
 st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 967 "parser.c"
+#line 968 "parser.c"
 	goto st0;
 st5:
 	if ( ++p == pe )
@@ -1024,14 +1025,21 @@ case 7:
 	_out: {}
 	}
 
-#line 338 "parser.rl"
+#line 339 "parser.rl"
 
     if (cs >= JSON_float_first_final) {
         long len = p - json->memo;
         fbuffer_clear(json->fbuffer);
         fbuffer_append(json->fbuffer, json->memo, len);
         fbuffer_append_char(json->fbuffer, '\0');
-        *result = rb_float_new(rb_cstr_to_dbl(FBUFFER_PTR(json->fbuffer), 1));
+        if (NIL_P(json->decimal_class)) {
+          *result = rb_float_new(rb_cstr_to_dbl(FBUFFER_PTR(json->fbuffer), 1));
+        }
+        else {
+          VALUE text;
+          text = rb_str_new2(FBUFFER_PTR(json->fbuffer));
+          *result = rb_funcall(json->decimal_class, i_new, 1, text);
+        }
         return p + 1;
     } else {
         return NULL;
@@ -1040,7 +1048,7 @@ case 7:
 
 
 
-#line 1044 "parser.c"
+#line 1052 "parser.c"
 static const int JSON_array_start = 1;
 static const int JSON_array_first_final = 17;
 static const int JSON_array_error = 0;
@@ -1048,7 +1056,7 @@ static const int JSON_array_error = 0;
 static const int JSON_array_en_main = 1;
 
 
-#line 381 "parser.rl"
+#line 389 "parser.rl"
 
 
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -1062,14 +1070,14 @@ static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *resul
     *result = NIL_P(array_class) ? rb_ary_new() : rb_class_new_instance(0, 0, array_class);
 
 
-#line 1066 "parser.c"
+#line 1074 "parser.c"
 	{
 	cs = JSON_array_start;
 	}
 
-#line 394 "parser.rl"
+#line 402 "parser.rl"
 
-#line 1073 "parser.c"
+#line 1081 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1108,7 +1116,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 358 "parser.rl"
+#line 366 "parser.rl"
 	{
         VALUE v = Qnil;
         char *np = JSON_parse_value(json, p, pe, &v);
@@ -1128,7 +1136,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 1132 "parser.c"
+#line 1140 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st3;
 		case 32: goto st3;
@@ -1228,14 +1236,14 @@ case 12:
 		goto st3;
 	goto st12;
 tr4:
-#line 373 "parser.rl"
+#line 381 "parser.rl"
 	{ p--; {p++; cs = 17; goto _out;} }
 	goto st17;
 st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1239 "parser.c"
+#line 1247 "parser.c"
 	goto st0;
 st13:
 	if ( ++p == pe )
@@ -1291,7 +1299,7 @@ case 16:
 	_out: {}
 	}
 
-#line 395 "parser.rl"
+#line 403 "parser.rl"
 
     if(cs >= JSON_array_first_final) {
         return p + 1;
@@ -1372,7 +1380,7 @@ static VALUE json_string_unescape(VALUE result, char *string, char *stringEnd)
 }
 
 
-#line 1376 "parser.c"
+#line 1384 "parser.c"
 static const int JSON_string_start = 1;
 static const int JSON_string_first_final = 8;
 static const int JSON_string_error = 0;
@@ -1380,7 +1388,7 @@ static const int JSON_string_error = 0;
 static const int JSON_string_en_main = 1;
 
 
-#line 494 "parser.rl"
+#line 502 "parser.rl"
 
 
 static int
@@ -1402,15 +1410,15 @@ static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *resu
 
     *result = rb_str_buf_new(0);
 
-#line 1406 "parser.c"
+#line 1414 "parser.c"
 	{
 	cs = JSON_string_start;
 	}
 
-#line 515 "parser.rl"
+#line 523 "parser.rl"
     json->memo = p;
 
-#line 1414 "parser.c"
+#line 1422 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1435,7 +1443,7 @@ case 2:
 		goto st0;
 	goto st2;
 tr2:
-#line 480 "parser.rl"
+#line 488 "parser.rl"
 	{
         *result = json_string_unescape(*result, json->memo + 1, p);
         if (NIL_P(*result)) {
@@ -1446,14 +1454,14 @@ tr2:
             {p = (( p + 1))-1;}
         }
     }
-#line 491 "parser.rl"
+#line 499 "parser.rl"
 	{ p--; {p++; cs = 8; goto _out;} }
 	goto st8;
 st8:
 	if ( ++p == pe )
 		goto _test_eof8;
 case 8:
-#line 1457 "parser.c"
+#line 1465 "parser.c"
 	goto st0;
 st3:
 	if ( ++p == pe )
@@ -1529,7 +1537,7 @@ case 7:
 	_out: {}
 	}
 
-#line 517 "parser.rl"
+#line 525 "parser.rl"
 
     if (json->create_additions && RTEST(match_string = json->match_string)) {
           VALUE klass;
@@ -1627,7 +1635,7 @@ static VALUE convert_encoding(VALUE source)
  *   the default.
  * * *create_additions*: If set to false, the Parser doesn't create
  *   additions even if a matching class and create_id was found. This option
- *   defaults to false.
+ *   defaults to true.
  * * *object_class*: Defaults to Hash
  * * *array_class*: Defaults to Array
  */
@@ -1700,6 +1708,12 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
             } else {
                 json->array_class = Qnil;
             }
+            tmp = ID2SYM(i_decimal_class);
+            if (option_given_p(opts, tmp)) {
+                json->decimal_class = rb_hash_aref(opts, tmp);
+            } else {
+                json->decimal_class = Qnil;
+            }
             tmp = ID2SYM(i_match_string);
             if (option_given_p(opts, tmp)) {
                 VALUE match_string = rb_hash_aref(opts, tmp);
@@ -1715,6 +1729,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
         json->create_id = rb_funcall(mJSON, i_create_id, 0);
         json->object_class = Qnil;
         json->array_class = Qnil;
+        json->decimal_class = Qnil;
     }
     source = rb_convert_type(source, T_STRING, "String", "to_str");
     if (!json->quirks_mode) {
@@ -1729,7 +1744,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 
-#line 1733 "parser.c"
+#line 1748 "parser.c"
 static const int JSON_start = 1;
 static const int JSON_first_final = 10;
 static const int JSON_error = 0;
@@ -1737,7 +1752,7 @@ static const int JSON_error = 0;
 static const int JSON_en_main = 1;
 
 
-#line 740 "parser.rl"
+#line 755 "parser.rl"
 
 
 static VALUE cParser_parse_strict(VALUE self)
@@ -1748,16 +1763,16 @@ static VALUE cParser_parse_strict(VALUE self)
     GET_PARSER;
 
 
-#line 1752 "parser.c"
+#line 1767 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 750 "parser.rl"
+#line 765 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 1761 "parser.c"
+#line 1776 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1813,7 +1828,7 @@ case 5:
 		goto st1;
 	goto st5;
 tr3:
-#line 729 "parser.rl"
+#line 744 "parser.rl"
 	{
         char *np;
         json->current_nesting = 1;
@@ -1822,7 +1837,7 @@ tr3:
     }
 	goto st10;
 tr4:
-#line 722 "parser.rl"
+#line 737 "parser.rl"
 	{
         char *np;
         json->current_nesting = 1;
@@ -1834,7 +1849,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 1838 "parser.c"
+#line 1853 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -1891,7 +1906,7 @@ case 9:
 	_out: {}
 	}
 
-#line 753 "parser.rl"
+#line 768 "parser.rl"
 
     if (cs >= JSON_first_final && p == pe) {
         return result;
@@ -1903,7 +1918,7 @@ case 9:
 
 
 
-#line 1907 "parser.c"
+#line 1922 "parser.c"
 static const int JSON_quirks_mode_start = 1;
 static const int JSON_quirks_mode_first_final = 10;
 static const int JSON_quirks_mode_error = 0;
@@ -1911,7 +1926,7 @@ static const int JSON_quirks_mode_error = 0;
 static const int JSON_quirks_mode_en_main = 1;
 
 
-#line 778 "parser.rl"
+#line 793 "parser.rl"
 
 
 static VALUE cParser_parse_quirks_mode(VALUE self)
@@ -1922,16 +1937,16 @@ static VALUE cParser_parse_quirks_mode(VALUE self)
     GET_PARSER;
 
 
-#line 1926 "parser.c"
+#line 1941 "parser.c"
 	{
 	cs = JSON_quirks_mode_start;
 	}
 
-#line 788 "parser.rl"
+#line 803 "parser.rl"
     p = json->source;
     pe = p + json->len;
 
-#line 1935 "parser.c"
+#line 1950 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1965,7 +1980,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 770 "parser.rl"
+#line 785 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -1975,7 +1990,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 1979 "parser.c"
+#line 1994 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2064,7 +2079,7 @@ case 9:
 	_out: {}
 	}
 
-#line 791 "parser.rl"
+#line 806 "parser.rl"
 
     if (cs >= JSON_quirks_mode_first_final && p == pe) {
         return result;
@@ -2106,6 +2121,7 @@ static void JSON_mark(JSON_Parser *json)
     rb_gc_mark_maybe(json->create_id);
     rb_gc_mark_maybe(json->object_class);
     rb_gc_mark_maybe(json->array_class);
+    rb_gc_mark_maybe(json->decimal_class);
     rb_gc_mark_maybe(json->match_string);
 }
 
@@ -2174,6 +2190,7 @@ void Init_parser()
     i_quirks_mode = rb_intern("quirks_mode");
     i_object_class = rb_intern("object_class");
     i_array_class = rb_intern("array_class");
+    i_decimal_class = rb_intern("decimal_class");
     i_match = rb_intern("match");
     i_match_string = rb_intern("match_string");
     i_key_p = rb_intern("key?");
@@ -2181,6 +2198,7 @@ void Init_parser()
     i_aset = rb_intern("[]=");
     i_aref = rb_intern("[]");
     i_leftshift = rb_intern("<<");
+    i_new = rb_intern("new");
 #ifdef HAVE_RUBY_ENCODING_H
     CEncoding_UTF_8 = rb_funcall(rb_path2class("Encoding"), rb_intern("find"), 1, rb_str_new2("utf-8"));
     CEncoding_UTF_16BE = rb_funcall(rb_path2class("Encoding"), rb_intern("find"), 1, rb_str_new2("utf-16be"));

--- a/ext/json/ext/parser/parser.h
+++ b/ext/json/ext/parser/parser.h
@@ -41,6 +41,7 @@ typedef struct JSON_ParserStruct {
     int quirks_mode;
     VALUE object_class;
     VALUE array_class;
+    VALUE decimal_class;
     int create_additions;
     VALUE match_string;
     FBuffer *fbuffer;

--- a/java/src/json/ext/Parser.java
+++ b/java/src/json/ext/Parser.java
@@ -56,6 +56,7 @@ public class Parser extends RubyObject {
     private boolean quirksMode;
     private RubyClass objectClass;
     private RubyClass arrayClass;
+    private RubyClass decimalClass;
     private RubyHash match_string;
 
     private static final int DEFAULT_MAX_NESTING = 100;
@@ -130,7 +131,7 @@ public class Parser extends RubyObject {
      * 
      * <dt><code>:create_additions</code>
      * <dd>If set to <code>false</code>, the Parser doesn't create additions
-     * even if a matchin class and <code>create_id</code> was found. This option
+     * even if a matching class and <code>create_id</code> was found. This option
      * defaults to <code>true</code>.
      *
      * <dt><code>:object_class</code>
@@ -138,6 +139,11 @@ public class Parser extends RubyObject {
      *
      * <dt><code>:array_class</code>
      * <dd>Defaults to Array.
+     *
+     * <dt><code>:decimal_class</code>
+     * <dd>Specifies which class to use instead of the default (Float) when
+     * parsing decimal numbers. This class must accept a single string argument
+     * in its constructor.
      *
      * <dt><code>:quirks_mode</code>
      * <dd>Enables quirks_mode for parser, that is for example parsing single
@@ -169,6 +175,7 @@ public class Parser extends RubyObject {
         this.createAdditions = opts.getBool("create_additions", false);
         this.objectClass     = opts.getClass("object_class", runtime.getHash());
         this.arrayClass      = opts.getClass("array_class", runtime.getArray());
+        this.decimalClass    = opts.getClass("decimal_class", null);
         this.match_string    = opts.getHash("match_string");
 
         this.vSource = args[0].convertToString();
@@ -337,11 +344,11 @@ public class Parser extends RubyObject {
         }
 
         
-// line 363 "Parser.rl"
+// line 370 "Parser.rl"
 
 
         
-// line 345 "Parser.java"
+// line 352 "Parser.java"
 private static byte[] init__JSON_value_actions_0()
 {
 	return new byte [] {
@@ -455,7 +462,7 @@ static final int JSON_value_error = 0;
 static final int JSON_value_en_main = 1;
 
 
-// line 469 "Parser.rl"
+// line 476 "Parser.rl"
 
 
         void parseValue(ParserResult res, int p, int pe) {
@@ -463,14 +470,14 @@ static final int JSON_value_en_main = 1;
             IRubyObject result = null;
 
             
-// line 467 "Parser.java"
+// line 474 "Parser.java"
 	{
 	cs = JSON_value_start;
 	}
 
-// line 476 "Parser.rl"
+// line 483 "Parser.rl"
             
-// line 474 "Parser.java"
+// line 481 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -496,13 +503,13 @@ case 1:
 	while ( _nacts-- > 0 ) {
 		switch ( _JSON_value_actions[_acts++] ) {
 	case 9:
-// line 454 "Parser.rl"
+// line 461 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 506 "Parser.java"
+// line 513 "Parser.java"
 		}
 	}
 
@@ -565,25 +572,25 @@ case 1:
 			switch ( _JSON_value_actions[_acts++] )
 			{
 	case 0:
-// line 371 "Parser.rl"
+// line 378 "Parser.rl"
 	{
                 result = getRuntime().getNil();
             }
 	break;
 	case 1:
-// line 374 "Parser.rl"
+// line 381 "Parser.rl"
 	{
                 result = getRuntime().getFalse();
             }
 	break;
 	case 2:
-// line 377 "Parser.rl"
+// line 384 "Parser.rl"
 	{
                 result = getRuntime().getTrue();
             }
 	break;
 	case 3:
-// line 380 "Parser.rl"
+// line 387 "Parser.rl"
 	{
                 if (parser.allowNaN) {
                     result = getConstant(CONST_NAN);
@@ -593,7 +600,7 @@ case 1:
             }
 	break;
 	case 4:
-// line 387 "Parser.rl"
+// line 394 "Parser.rl"
 	{
                 if (parser.allowNaN) {
                     result = getConstant(CONST_INFINITY);
@@ -603,7 +610,7 @@ case 1:
             }
 	break;
 	case 5:
-// line 394 "Parser.rl"
+// line 401 "Parser.rl"
 	{
                 if (pe > p + 9 - (parser.quirksMode ? 1 : 0) &&
                     absSubSequence(p, p + 9).equals(JSON_MINUS_INFINITY)) {
@@ -632,7 +639,7 @@ case 1:
             }
 	break;
 	case 6:
-// line 420 "Parser.rl"
+// line 427 "Parser.rl"
 	{
                 parseString(res, p, pe);
                 if (res.result == null) {
@@ -645,7 +652,7 @@ case 1:
             }
 	break;
 	case 7:
-// line 430 "Parser.rl"
+// line 437 "Parser.rl"
 	{
                 currentNesting++;
                 parseArray(res, p, pe);
@@ -660,7 +667,7 @@ case 1:
             }
 	break;
 	case 8:
-// line 442 "Parser.rl"
+// line 449 "Parser.rl"
 	{
                 currentNesting++;
                 parseObject(res, p, pe);
@@ -674,7 +681,7 @@ case 1:
                 }
             }
 	break;
-// line 678 "Parser.java"
+// line 685 "Parser.java"
 			}
 		}
 	}
@@ -694,7 +701,7 @@ case 5:
 	break; }
 	}
 
-// line 477 "Parser.rl"
+// line 484 "Parser.rl"
 
             if (cs >= JSON_value_first_final && result != null) {
                 res.update(result, p);
@@ -704,7 +711,7 @@ case 5:
         }
 
         
-// line 708 "Parser.java"
+// line 715 "Parser.java"
 private static byte[] init__JSON_integer_actions_0()
 {
 	return new byte [] {
@@ -803,7 +810,7 @@ static final int JSON_integer_error = 0;
 static final int JSON_integer_en_main = 1;
 
 
-// line 496 "Parser.rl"
+// line 503 "Parser.rl"
 
 
         void parseInteger(ParserResult res, int p, int pe) {
@@ -821,15 +828,15 @@ static final int JSON_integer_en_main = 1;
             int cs = EVIL;
 
             
-// line 825 "Parser.java"
+// line 832 "Parser.java"
 	{
 	cs = JSON_integer_start;
 	}
 
-// line 513 "Parser.rl"
+// line 520 "Parser.rl"
             int memo = p;
             
-// line 833 "Parser.java"
+// line 840 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -910,13 +917,13 @@ case 1:
 			switch ( _JSON_integer_actions[_acts++] )
 			{
 	case 0:
-// line 490 "Parser.rl"
+// line 497 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 920 "Parser.java"
+// line 927 "Parser.java"
 			}
 		}
 	}
@@ -936,7 +943,7 @@ case 5:
 	break; }
 	}
 
-// line 515 "Parser.rl"
+// line 522 "Parser.rl"
 
             if (cs < JSON_integer_first_final) {
                 return -1;
@@ -958,7 +965,7 @@ case 5:
         }
 
         
-// line 962 "Parser.java"
+// line 969 "Parser.java"
 private static byte[] init__JSON_float_actions_0()
 {
 	return new byte [] {
@@ -1060,7 +1067,7 @@ static final int JSON_float_error = 0;
 static final int JSON_float_en_main = 1;
 
 
-// line 550 "Parser.rl"
+// line 557 "Parser.rl"
 
 
         void parseFloat(ParserResult res, int p, int pe) {
@@ -1069,7 +1076,9 @@ static final int JSON_float_en_main = 1;
                 res.update(null, p);
                 return;
             }
-            RubyFloat number = createFloat(p, new_p);
+            IRubyObject number = parser.decimalClass == null ?
+                createFloat(p, new_p) : createCustomDecimal(p, new_p);
+
             res.update(number, new_p + 1);
             return;
         }
@@ -1078,15 +1087,15 @@ static final int JSON_float_en_main = 1;
             int cs = EVIL;
 
             
-// line 1082 "Parser.java"
+// line 1091 "Parser.java"
 	{
 	cs = JSON_float_start;
 	}
 
-// line 567 "Parser.rl"
+// line 576 "Parser.rl"
             int memo = p;
             
-// line 1090 "Parser.java"
+// line 1099 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1167,13 +1176,13 @@ case 1:
 			switch ( _JSON_float_actions[_acts++] )
 			{
 	case 0:
-// line 541 "Parser.rl"
+// line 548 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1177 "Parser.java"
+// line 1186 "Parser.java"
 			}
 		}
 	}
@@ -1193,7 +1202,7 @@ case 5:
 	break; }
 	}
 
-// line 569 "Parser.rl"
+// line 578 "Parser.rl"
 
             if (cs < JSON_float_first_final) {
                 return -1;
@@ -1207,9 +1216,16 @@ case 5:
             ByteList num = absSubSequence(p, new_p);
             return RubyFloat.newFloat(runtime, dc.parse(num, true, runtime.is1_9()));
         }
+        
+        IRubyObject createCustomDecimal(int p, int new_p) {
+            Ruby runtime = getRuntime();
+            ByteList num = absSubSequence(p, new_p);
+            IRubyObject numString = runtime.newString(num.toString());
+            return parser.decimalClass.callMethod(context, "new", numString);
+        }
 
         
-// line 1213 "Parser.java"
+// line 1229 "Parser.java"
 private static byte[] init__JSON_string_actions_0()
 {
 	return new byte [] {
@@ -1311,7 +1327,7 @@ static final int JSON_string_error = 0;
 static final int JSON_string_en_main = 1;
 
 
-// line 614 "Parser.rl"
+// line 630 "Parser.rl"
 
 
         void parseString(ParserResult res, int p, int pe) {
@@ -1319,15 +1335,15 @@ static final int JSON_string_en_main = 1;
             IRubyObject result = null;
 
             
-// line 1323 "Parser.java"
+// line 1339 "Parser.java"
 	{
 	cs = JSON_string_start;
 	}
 
-// line 621 "Parser.rl"
+// line 637 "Parser.rl"
             int memo = p;
             
-// line 1331 "Parser.java"
+// line 1347 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1408,7 +1424,7 @@ case 1:
 			switch ( _JSON_string_actions[_acts++] )
 			{
 	case 0:
-// line 589 "Parser.rl"
+// line 605 "Parser.rl"
 	{
                 int offset = byteList.begin();
                 ByteList decoded = decoder.decode(byteList, memo + 1 - offset,
@@ -1423,13 +1439,13 @@ case 1:
             }
 	break;
 	case 1:
-// line 602 "Parser.rl"
+// line 618 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1433 "Parser.java"
+// line 1449 "Parser.java"
 			}
 		}
 	}
@@ -1449,7 +1465,7 @@ case 5:
 	break; }
 	}
 
-// line 623 "Parser.rl"
+// line 639 "Parser.rl"
 
             if (parser.createAdditions) {
                 RubyHash match_string = parser.match_string;
@@ -1488,7 +1504,7 @@ case 5:
         }
 
         
-// line 1492 "Parser.java"
+// line 1508 "Parser.java"
 private static byte[] init__JSON_array_actions_0()
 {
 	return new byte [] {
@@ -1601,7 +1617,7 @@ static final int JSON_array_error = 0;
 static final int JSON_array_en_main = 1;
 
 
-// line 697 "Parser.rl"
+// line 713 "Parser.rl"
 
 
         void parseArray(ParserResult res, int p, int pe) {
@@ -1621,14 +1637,14 @@ static final int JSON_array_en_main = 1;
             }
 
             
-// line 1625 "Parser.java"
+// line 1641 "Parser.java"
 	{
 	cs = JSON_array_start;
 	}
 
-// line 716 "Parser.rl"
+// line 732 "Parser.rl"
             
-// line 1632 "Parser.java"
+// line 1648 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1709,7 +1725,7 @@ case 1:
 			switch ( _JSON_array_actions[_acts++] )
 			{
 	case 0:
-// line 666 "Parser.rl"
+// line 682 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -1726,13 +1742,13 @@ case 1:
             }
 	break;
 	case 1:
-// line 681 "Parser.rl"
+// line 697 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1736 "Parser.java"
+// line 1752 "Parser.java"
 			}
 		}
 	}
@@ -1752,7 +1768,7 @@ case 5:
 	break; }
 	}
 
-// line 717 "Parser.rl"
+// line 733 "Parser.rl"
 
             if (cs >= JSON_array_first_final) {
                 res.update(result, p + 1);
@@ -1762,7 +1778,7 @@ case 5:
         }
 
         
-// line 1766 "Parser.java"
+// line 1782 "Parser.java"
 private static byte[] init__JSON_object_actions_0()
 {
 	return new byte [] {
@@ -1885,7 +1901,7 @@ static final int JSON_object_error = 0;
 static final int JSON_object_en_main = 1;
 
 
-// line 776 "Parser.rl"
+// line 792 "Parser.rl"
 
 
         void parseObject(ParserResult res, int p, int pe) {
@@ -1910,14 +1926,14 @@ static final int JSON_object_en_main = 1;
             }
 
             
-// line 1914 "Parser.java"
+// line 1930 "Parser.java"
 	{
 	cs = JSON_object_start;
 	}
 
-// line 800 "Parser.rl"
+// line 816 "Parser.rl"
             
-// line 1921 "Parser.java"
+// line 1937 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1998,7 +2014,7 @@ case 1:
 			switch ( _JSON_object_actions[_acts++] )
 			{
 	case 0:
-// line 731 "Parser.rl"
+// line 747 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -2015,7 +2031,7 @@ case 1:
             }
 	break;
 	case 1:
-// line 746 "Parser.rl"
+// line 762 "Parser.rl"
 	{
                 parseString(res, p, pe);
                 if (res.result == null) {
@@ -2035,13 +2051,13 @@ case 1:
             }
 	break;
 	case 2:
-// line 764 "Parser.rl"
+// line 780 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 2045 "Parser.java"
+// line 2061 "Parser.java"
 			}
 		}
 	}
@@ -2061,7 +2077,7 @@ case 5:
 	break; }
 	}
 
-// line 801 "Parser.rl"
+// line 817 "Parser.rl"
 
             if (cs < JSON_object_first_final) {
                 res.update(null, p + 1);
@@ -2094,7 +2110,7 @@ case 5:
         }
 
         
-// line 2098 "Parser.java"
+// line 2114 "Parser.java"
 private static byte[] init__JSON_actions_0()
 {
 	return new byte [] {
@@ -2198,7 +2214,7 @@ static final int JSON_error = 0;
 static final int JSON_en_main = 1;
 
 
-// line 866 "Parser.rl"
+// line 882 "Parser.rl"
 
 
         public IRubyObject parseStrict() {
@@ -2208,16 +2224,16 @@ static final int JSON_en_main = 1;
             ParserResult res = new ParserResult();
 
             
-// line 2212 "Parser.java"
+// line 2228 "Parser.java"
 	{
 	cs = JSON_start;
 	}
 
-// line 875 "Parser.rl"
+// line 891 "Parser.rl"
             p = byteList.begin();
             pe = p + byteList.length();
             
-// line 2221 "Parser.java"
+// line 2237 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -2298,7 +2314,7 @@ case 1:
 			switch ( _JSON_actions[_acts++] )
 			{
 	case 0:
-// line 838 "Parser.rl"
+// line 854 "Parser.rl"
 	{
                 currentNesting = 1;
                 parseObject(res, p, pe);
@@ -2312,7 +2328,7 @@ case 1:
             }
 	break;
 	case 1:
-// line 850 "Parser.rl"
+// line 866 "Parser.rl"
 	{
                 currentNesting = 1;
                 parseArray(res, p, pe);
@@ -2325,7 +2341,7 @@ case 1:
                 }
             }
 	break;
-// line 2329 "Parser.java"
+// line 2345 "Parser.java"
 			}
 		}
 	}
@@ -2345,7 +2361,7 @@ case 5:
 	break; }
 	}
 
-// line 878 "Parser.rl"
+// line 894 "Parser.rl"
 
             if (cs >= JSON_first_final && p == pe) {
                 return result;
@@ -2355,7 +2371,7 @@ case 5:
         }
 
         
-// line 2359 "Parser.java"
+// line 2375 "Parser.java"
 private static byte[] init__JSON_quirks_mode_actions_0()
 {
 	return new byte [] {
@@ -2458,7 +2474,7 @@ static final int JSON_quirks_mode_error = 0;
 static final int JSON_quirks_mode_en_main = 1;
 
 
-// line 906 "Parser.rl"
+// line 922 "Parser.rl"
 
 
         public IRubyObject parseQuirksMode() {
@@ -2468,16 +2484,16 @@ static final int JSON_quirks_mode_en_main = 1;
             ParserResult res = new ParserResult();
 
             
-// line 2472 "Parser.java"
+// line 2488 "Parser.java"
 	{
 	cs = JSON_quirks_mode_start;
 	}
 
-// line 915 "Parser.rl"
+// line 931 "Parser.rl"
             p = byteList.begin();
             pe = p + byteList.length();
             
-// line 2481 "Parser.java"
+// line 2497 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -2558,7 +2574,7 @@ case 1:
 			switch ( _JSON_quirks_mode_actions[_acts++] )
 			{
 	case 0:
-// line 892 "Parser.rl"
+// line 908 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -2570,7 +2586,7 @@ case 1:
                 }
             }
 	break;
-// line 2574 "Parser.java"
+// line 2590 "Parser.java"
 			}
 		}
 	}
@@ -2590,7 +2606,7 @@ case 5:
 	break; }
 	}
 
-// line 918 "Parser.rl"
+// line 934 "Parser.rl"
 
             if (cs >= JSON_quirks_mode_first_final && p == pe) {
                 return result;

--- a/lib/json/pure/parser.rb
+++ b/lib/json/pure/parser.rb
@@ -68,6 +68,9 @@ module JSON
       #   option defaults to false.
       # * *object_class*: Defaults to Hash
       # * *array_class*: Defaults to Array
+      # * *decimal_class*: Specifies which class to use instead of the default
+      #    (Float) when parsing decimal numbers. This class must accept a single
+      #    string argument in its constructor.
       # * *quirks_mode*: Enables quirks_mode for parser, that is for example
       #   parsing single JSON values instead of documents is possible.
       def initialize(source, opts = {})
@@ -93,6 +96,7 @@ module JSON
         @create_id = @create_additions ? JSON.create_id : nil
         @object_class = opts[:object_class] || Hash
         @array_class  = opts[:array_class] || Array
+        @decimal_class = opts[:decimal_class]
         @match_string = opts[:match_string]
       end
 
@@ -245,7 +249,7 @@ module JSON
       def parse_value
         case
         when scan(FLOAT)
-          Float(self[1])
+          @decimal_class && @decimal_class.new(self[1]) || Float(self[1])
         when scan(INTEGER)
           Integer(self[1])
         when scan(TRUE)


### PR DESCRIPTION
This commit addresses issue [#219 in flori/json](https://github.com/flori/json/issues/219). A new `:decimal_class` option for the parser allows the caller to select an alternate object class when a decimal number is parsed, instead of the default `Float`. The new class should have a one-argument constructor and is passed the read decimal as a string.
