### PR TITLE
JSON::State is not using the parameter space_before

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -871,6 +871,7 @@ static FBuffer *cState_prepare_buffer(VALUE self)
     } else {
         state->object_delim2 = fbuffer_alloc(16);
     }
+    if (state->space_before) fbuffer_append(state->object_delim2, state->space_before, state->space_before_len);
     fbuffer_append_char(state->object_delim2, ':');
     if (state->space) fbuffer_append(state->object_delim2, state->space, state->space_len);
 

--- a/tests/test_json_generate.rb
+++ b/tests/test_json_generate.rb
@@ -73,6 +73,19 @@ EOT
     assert_equal '666', pretty_generate(666, :quirks_mode => true)
   end
 
+  def test_generate_custom
+    state = State.new(space_before: " ", space: "   ", indent:"<i>", object_nl: "\n", array_nl: "<a_nl>")
+    json = generate({1=>{2=>3,4=>[5,6]}}, state)
+    assert_equal(<<'EOT'.chomp, json)
+{
+<i>"1" :   {
+<i><i>"2" :   3,
+<i><i>"4" :   [<a_nl><i><i><i>5,<a_nl><i><i><i>6<a_nl><i><i>]
+<i>}
+}
+EOT
+  end
+
   def test_fast_generate
     json = fast_generate(@hash)
     assert_equal(JSON.parse(@json2), JSON.parse(json))

--- a/tests/test_json_generate.rb
+++ b/tests/test_json_generate.rb
@@ -74,7 +74,7 @@ EOT
   end
 
   def test_generate_custom
-    state = State.new(space_before: " ", space: "   ", indent:"<i>", object_nl: "\n", array_nl: "<a_nl>")
+    state = State.new(:space_before => " ", :space => "   ", :indent => "<i>", :object_nl => "\n", :array_nl => "<a_nl>")
     json = generate({1=>{2=>3,4=>[5,6]}}, state)
     assert_equal(<<'EOT'.chomp, json)
 {


### PR DESCRIPTION
The parameter space_before, documented as a string that is put before a : pair delimiter, is never used. 

Script to reproduce the issue:

```ruby
require 'json'
state = JSON::Ext::Generator::State.new( space_before: "bef_delim", space: "aft_delim")
puts JSON.generate({'1' => 2},state)
```

This solves #225 

Link to the issue in the ruby tracker: 
https://bugs.ruby-lang.org/issues/10317