### PR TITLE
fix regression for 1.8.2

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -528,8 +528,7 @@ static const rb_data_type_t JSON_Generator_State_type = {
 
 static JSON_Generator_State *State_allocate(void)
 {
-    JSON_Generator_State *state = ALLOC(JSON_Generator_State);
-    MEMZERO(state, JSON_Generator_State, 1);
+    JSON_Generator_State *state = ZALLOC(JSON_Generator_State);
     return state;
 }
 

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -519,10 +519,8 @@ static size_t State_memsize(const void *ptr)
 static const rb_data_type_t JSON_Generator_State_type = {
     "JSON/Generator/State",
     {NULL, State_free, State_memsize,},
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     0, 0,
     RUBY_TYPED_FREE_IMMEDIATELY,
-#endif
 };
 #endif
 

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -519,8 +519,10 @@ static size_t State_memsize(const void *ptr)
 static const rb_data_type_t JSON_Generator_State_type = {
     "JSON/Generator/State",
     {NULL, State_free, State_memsize,},
+#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     0, 0,
     RUBY_TYPED_FREE_IMMEDIATELY,
+#endif
 };
 #endif
 

--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -147,6 +147,15 @@ static VALUE cState_ascii_only_p(VALUE self);
 static VALUE cState_depth(VALUE self);
 static VALUE cState_depth_set(VALUE self, VALUE depth);
 static FBuffer *cState_prepare_buffer(VALUE self);
+#ifndef ZALLOC
+#define ZALLOC(type) ((type *)ruby_zalloc(sizeof(type)))
+static inline void *ruby_zalloc(size_t n)
+{
+    void *p = ruby_xmalloc(n);
+    memset(p, 0, n);
+    return p;
+}
+#endif
 #ifdef TypedData_Wrap_Struct
 static const rb_data_type_t JSON_Generator_State_type;
 #define NEW_TYPEDDATA_WRAPPER 1

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -89,11 +89,11 @@ static ID i_json_creatable_p, i_json_create, i_create_id, i_create_additions,
 
 
 #line 92 "parser.c"
-static const int JSON_object_start = 1;
-static const int JSON_object_first_final = 27;
-static const int JSON_object_error = 0;
+enum {JSON_object_start = 1};
+enum {JSON_object_first_final = 27};
+enum {JSON_object_error = 0};
 
-static const int JSON_object_en_main = 1;
+enum {JSON_object_en_main = 1};
 
 
 #line 151 "parser.rl"
@@ -467,11 +467,11 @@ case 26:
 
 
 #line 470 "parser.c"
-static const int JSON_value_start = 1;
-static const int JSON_value_first_final = 21;
-static const int JSON_value_error = 0;
+enum {JSON_value_start = 1};
+enum {JSON_value_first_final = 21};
+enum {JSON_value_error = 0};
 
-static const int JSON_value_en_main = 1;
+enum {JSON_value_en_main = 1};
 
 
 #line 271 "parser.rl"
@@ -776,11 +776,11 @@ case 20:
 
 
 #line 779 "parser.c"
-static const int JSON_integer_start = 1;
-static const int JSON_integer_first_final = 3;
-static const int JSON_integer_error = 0;
+enum {JSON_integer_start = 1};
+enum {JSON_integer_first_final = 3};
+enum {JSON_integer_error = 0};
 
-static const int JSON_integer_en_main = 1;
+enum {JSON_integer_en_main = 1};
 
 
 #line 295 "parser.rl"
@@ -875,11 +875,11 @@ case 5:
 
 
 #line 878 "parser.c"
-static const int JSON_float_start = 1;
-static const int JSON_float_first_final = 8;
-static const int JSON_float_error = 0;
+enum {JSON_float_start = 1};
+enum {JSON_float_first_final = 8};
+enum {JSON_float_error = 0};
 
-static const int JSON_float_en_main = 1;
+enum {JSON_float_en_main = 1};
 
 
 #line 329 "parser.rl"
@@ -1041,11 +1041,11 @@ case 7:
 
 
 #line 1044 "parser.c"
-static const int JSON_array_start = 1;
-static const int JSON_array_first_final = 17;
-static const int JSON_array_error = 0;
+enum {JSON_array_start = 1};
+enum {JSON_array_first_final = 17};
+enum {JSON_array_error = 0};
 
-static const int JSON_array_en_main = 1;
+enum {JSON_array_en_main = 1};
 
 
 #line 381 "parser.rl"
@@ -1373,11 +1373,11 @@ static VALUE json_string_unescape(VALUE result, char *string, char *stringEnd)
 
 
 #line 1376 "parser.c"
-static const int JSON_string_start = 1;
-static const int JSON_string_first_final = 8;
-static const int JSON_string_error = 0;
+enum {JSON_string_start = 1};
+enum {JSON_string_first_final = 8};
+enum {JSON_string_error = 0};
 
-static const int JSON_string_en_main = 1;
+enum {JSON_string_en_main = 1};
 
 
 #line 494 "parser.rl"
@@ -1730,11 +1730,11 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 
 
 #line 1733 "parser.c"
-static const int JSON_start = 1;
-static const int JSON_first_final = 10;
-static const int JSON_error = 0;
+enum {JSON_start = 1};
+enum {JSON_first_final = 10};
+enum {JSON_error = 0};
 
-static const int JSON_en_main = 1;
+enum {JSON_en_main = 1};
 
 
 #line 740 "parser.rl"
@@ -1904,11 +1904,11 @@ case 9:
 
 
 #line 1907 "parser.c"
-static const int JSON_quirks_mode_start = 1;
-static const int JSON_quirks_mode_first_final = 10;
-static const int JSON_quirks_mode_error = 0;
+enum {JSON_quirks_mode_start = 1};
+enum {JSON_quirks_mode_first_final = 10};
+enum {JSON_quirks_mode_error = 0};
 
-static const int JSON_quirks_mode_en_main = 1;
+enum {JSON_quirks_mode_en_main = 1};
 
 
 #line 778 "parser.rl"
@@ -2127,10 +2127,8 @@ static size_t JSON_memsize(const void *ptr)
 static const rb_data_type_t JSON_Parser_type = {
     "JSON/Parser",
     {JSON_mark, JSON_free, JSON_memsize,},
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     0, 0,
     RUBY_TYPED_FREE_IMMEDIATELY,
-#endif
 };
 #endif
 
@@ -2164,7 +2162,7 @@ static VALUE cParser_quirks_mode_p(VALUE self)
 }
 
 
-void Init_parser()
+void Init_parser(void)
 {
     rb_require("json/common");
     mJSON = rb_define_module("JSON");

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -2094,8 +2094,7 @@ static VALUE cParser_parse(VALUE self)
 
 static JSON_Parser *JSON_allocate(void)
 {
-    JSON_Parser *json = ALLOC(JSON_Parser);
-    MEMZERO(json, JSON_Parser, 1);
+    JSON_Parser *json = ZALLOC(JSON_Parser);
     json->fbuffer = fbuffer_alloc(0);
     return json;
 }

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -2127,8 +2127,10 @@ static size_t JSON_memsize(const void *ptr)
 static const rb_data_type_t JSON_Parser_type = {
     "JSON/Parser",
     {JSON_mark, JSON_free, JSON_memsize,},
+#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     0, 0,
     RUBY_TYPED_FREE_IMMEDIATELY,
+#endif
 };
 #endif
 

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -28,16 +28,16 @@ static UTF32 unescape_unicode(const unsigned char *p)
     UTF32 result = 0;
     b = digit_values[p[0]];
     if (b < 0) return UNI_REPLACEMENT_CHAR;
-    result = (result << 4) | b;
+    result = (result << 4) | (unsigned char)b;
     b = digit_values[p[1]];
-    result = (result << 4) | b;
     if (b < 0) return UNI_REPLACEMENT_CHAR;
+    result = (result << 4) | (unsigned char)b;
     b = digit_values[p[2]];
-    result = (result << 4) | b;
     if (b < 0) return UNI_REPLACEMENT_CHAR;
+    result = (result << 4) | (unsigned char)b;
     b = digit_values[p[3]];
-    result = (result << 4) | b;
     if (b < 0) return UNI_REPLACEMENT_CHAR;
+    result = (result << 4) | (unsigned char)b;
     return result;
 }
 

--- a/ext/json/ext/parser/parser.h
+++ b/ext/json/ext/parser/parser.h
@@ -73,6 +73,15 @@ static void JSON_mark(void *json);
 static void JSON_free(void *json);
 static VALUE cJSON_parser_s_allocate(VALUE klass);
 static VALUE cParser_source(VALUE self);
+#ifndef ZALLOC
+#define ZALLOC(type) ((type *)ruby_zalloc(sizeof(type)))
+static inline void *ruby_zalloc(size_t n)
+{
+    void *p = ruby_xmalloc(n);
+    memset(p, 0, n);
+    return p;
+}
+#endif
 #ifdef TypedData_Wrap_Struct
 static const rb_data_type_t JSON_Parser_type;
 #define NEW_TYPEDDATA_WRAPPER 1

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -850,8 +850,10 @@ static size_t JSON_memsize(const void *ptr)
 static const rb_data_type_t JSON_Parser_type = {
     "JSON/Parser",
     {JSON_mark, JSON_free, JSON_memsize,},
+#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     0, 0,
     RUBY_TYPED_FREE_IMMEDIATELY,
+#endif
 };
 #endif
 

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -850,10 +850,8 @@ static size_t JSON_memsize(const void *ptr)
 static const rb_data_type_t JSON_Parser_type = {
     "JSON/Parser",
     {JSON_mark, JSON_free, JSON_memsize,},
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     0, 0,
     RUBY_TYPED_FREE_IMMEDIATELY,
-#endif
 };
 #endif
 

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -817,8 +817,7 @@ static VALUE cParser_parse(VALUE self)
 
 static JSON_Parser *JSON_allocate(void)
 {
-    JSON_Parser *json = ALLOC(JSON_Parser);
-    MEMZERO(json, JSON_Parser, 1);
+    JSON_Parser *json = ZALLOC(JSON_Parser);
     json->fbuffer = fbuffer_alloc(0);
     return json;
 }

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -26,16 +26,16 @@ static UTF32 unescape_unicode(const unsigned char *p)
     UTF32 result = 0;
     b = digit_values[p[0]];
     if (b < 0) return UNI_REPLACEMENT_CHAR;
-    result = (result << 4) | b;
+    result = (result << 4) | (unsigned char)b;
     b = digit_values[p[1]];
-    result = (result << 4) | b;
     if (b < 0) return UNI_REPLACEMENT_CHAR;
+    result = (result << 4) | (unsigned char)b;
     b = digit_values[p[2]];
-    result = (result << 4) | b;
     if (b < 0) return UNI_REPLACEMENT_CHAR;
+    result = (result << 4) | (unsigned char)b;
     b = digit_values[p[3]];
-    result = (result << 4) | b;
     if (b < 0) return UNI_REPLACEMENT_CHAR;
+    result = (result << 4) | (unsigned char)b;
     return result;
 }
 
@@ -887,7 +887,7 @@ static VALUE cParser_quirks_mode_p(VALUE self)
 }
 
 
-void Init_parser()
+void Init_parser(void)
 {
     rb_require("json/common");
     mJSON = rb_define_module("JSON");


### PR DESCRIPTION
I cherry-picked some regression of 1.8.2

 * added ZALLOC macro, and replace it.
 * apply [r49027](https://github.com/ruby/ruby/commit/993f22cb1bba82be52e08e7132af003ae432163e)

/cc @zzak 