### PR TITLE
Suppress warning: already initialized constant XXX

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -163,11 +163,11 @@ task :version do
     v.puts <<EOT
 module JSON
   # JSON version
-  VERSION         = '#{PKG_VERSION}'
-  VERSION_ARRAY   = VERSION.split(/\\./).map { |x| x.to_i } # :nodoc:
-  VERSION_MAJOR   = VERSION_ARRAY[0] # :nodoc:
-  VERSION_MINOR   = VERSION_ARRAY[1] # :nodoc:
-  VERSION_BUILD   = VERSION_ARRAY[2] # :nodoc:
+  VERSION         = '#{PKG_VERSION}' unless defined? VERSION
+  VERSION_ARRAY   = VERSION.split(/\./).map { |x| x.to_i } unless defined? VERSION_ARRAY # :nodoc:
+  VERSION_MAJOR   = VERSION_ARRAY[0] unless defined? VERSION_MAJOR # :nodoc:
+  VERSION_MINOR   = VERSION_ARRAY[1] unless defined? VERSION_MINOR # :nodoc:
+  VERSION_BUILD   = VERSION_ARRAY[2] unless defined? VERSION_BUILD # :nodoc:
 end
 EOT
   end

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -96,11 +96,11 @@ module JSON
   end
   self.create_id = 'json_class'
 
-  NaN           = 0.0/0
+  NaN           = 0.0/0 unless defined? NaN
 
-  Infinity      = 1.0/0
+  Infinity      = 1.0/0 unless defined? Infinity
 
-  MinusInfinity = -Infinity
+  MinusInfinity = -Infinity unless defined? MinusInfinity
 
   # The base exception for JSON errors.
   class JSONError < StandardError
@@ -125,7 +125,7 @@ module JSON
   # This exception is raised if a generator or unparser error occurs.
   class GeneratorError < JSONError; end
   # For backwards compatibility
-  UnparserError = GeneratorError
+  UnparserError = GeneratorError unless defined? UnparserError
 
   # This exception is raised if the required unicode support is missing on the
   # system. Usually this means that the iconv library is not installed.

--- a/lib/json/version.rb
+++ b/lib/json/version.rb
@@ -1,8 +1,8 @@
 module JSON
   # JSON version
-  VERSION         = '1.8.3'
-  VERSION_ARRAY   = VERSION.split(/\./).map { |x| x.to_i } # :nodoc:
-  VERSION_MAJOR   = VERSION_ARRAY[0] # :nodoc:
-  VERSION_MINOR   = VERSION_ARRAY[1] # :nodoc:
-  VERSION_BUILD   = VERSION_ARRAY[2] # :nodoc:
+  VERSION         = '1.8.3' unless defined? VERSION
+  VERSION_ARRAY   = VERSION.split(/./).map { |x| x.to_i } unless defined? VERSION_ARRAY # :nodoc:
+  VERSION_MAJOR   = VERSION_ARRAY[0] unless defined? VERSION_MAJOR # :nodoc:
+  VERSION_MINOR   = VERSION_ARRAY[1] unless defined? VERSION_MINOR # :nodoc:
+  VERSION_BUILD   = VERSION_ARRAY[2] unless defined? VERSION_BUILD # :nodoc:
 end


### PR DESCRIPTION
This pull request suppresses following warning: 
```
warning: already initialized constant CONSTANT
warning: previous definition of CONSTANT was here
```

Addresses https://github.com/flori/json/issues/177

The idea is based on this answer in Stack Overflow:
http://stackoverflow.com/questions/29093461/chefspec-loads-libraries-repeatedly-and-gives-the-warning-already-initialized-c
