### PR TITLE
RB_GC_GUARD to protect from premature GC

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -216,6 +216,7 @@ static void convert_UTF8_to_JSON_ASCII(FBuffer *buffer, VALUE string)
             unicode_escape_to_buffer(buffer, buf, (UTF16)((ch & halfMask) + UNI_SUR_LOW_START));
         }
     }
+    RB_GC_GUARD(string);
 }
 
 /* Converts string to a JSON string in FBuffer buffer, where only the
@@ -926,7 +927,10 @@ static int isArrayOrObject(VALUE string)
     if (string_len < 2) return 0;
     for (; p < q && isspace((unsigned char)*p); p++);
     for (; q > p && isspace((unsigned char)*q); q--);
-    return (*p == '[' && *q == ']') || (*p == '{' && *q == '}');
+
+    int retval = (*p == '[' && *q == ']') || (*p == '{' && *q == '}');
+    RB_GC_GUARD(string);
+    return retval;
 }
 
 /*


### PR DESCRIPTION
Context
-----------

I have been auditing some third-party Gems for memory errors in our app, which I believe are caused by [premature GC in C extensions](https://github.com/ruby/ruby/blob/trunk/doc/extension.rdoc#appendix-e-rb_gc_guard-to-protect-from-premature-gc).

Change
------------

In `static void convert_UTF8_to_JSON_ASCII(FBuffer *, VALUE)`, `string` is passed by value but isn't referenced after we take a pointer to it (`source`), so could be optimised away after that. A new `Exception` object being raised could cause a GC to clean up `string`, invalidating `source`. I introduce `RB_GC_GUARD(string);` later in the function to prevent this.

`static int isArrayOrObject(VALUE)` looks safe to me at the moment, but I've added the guard just-in-case. Should an exception be introduced, this would have the same issue as above.

