### PR TITLE
Remove comments from core classes in json/add

### DIFF
--- a/lib/json/add/date.rb
+++ b/lib/json/add/date.rb
@@ -3,7 +3,6 @@ unless defined?(::JSON::JSON_LOADED) and ::JSON::JSON_LOADED
 end
 require 'date'
 
-# Date serialization/deserialization
 class Date
 
   # Deserializes JSON string by converting Julian year <tt>y</tt>, month

--- a/lib/json/add/date_time.rb
+++ b/lib/json/add/date_time.rb
@@ -3,7 +3,6 @@ unless defined?(::JSON::JSON_LOADED) and ::JSON::JSON_LOADED
 end
 require 'date'
 
-# DateTime serialization/deserialization
 class DateTime
 
   # Deserializes JSON string by converting year <tt>y</tt>, month <tt>m</tt>,

--- a/lib/json/add/exception.rb
+++ b/lib/json/add/exception.rb
@@ -2,7 +2,6 @@ unless defined?(::JSON::JSON_LOADED) and ::JSON::JSON_LOADED
   require 'json'
 end
 
-# Exception serialization/deserialization
 class Exception
 
   # Deserializes JSON string by constructing new Exception object with message

--- a/lib/json/add/ostruct.rb
+++ b/lib/json/add/ostruct.rb
@@ -3,7 +3,6 @@ unless defined?(::JSON::JSON_LOADED) and ::JSON::JSON_LOADED
 end
 require 'ostruct'
 
-# OpenStruct serialization/deserialization
 class OpenStruct
 
   # Deserializes JSON string by constructing new Struct object with values

--- a/lib/json/add/range.rb
+++ b/lib/json/add/range.rb
@@ -2,7 +2,6 @@ unless defined?(::JSON::JSON_LOADED) and ::JSON::JSON_LOADED
   require 'json'
 end
 
-# Range serialization/deserialization
 class Range
 
   # Deserializes JSON string by constructing new Range object with arguments

--- a/lib/json/add/regexp.rb
+++ b/lib/json/add/regexp.rb
@@ -2,7 +2,6 @@ unless defined?(::JSON::JSON_LOADED) and ::JSON::JSON_LOADED
   require 'json'
 end
 
-# Regexp serialization/deserialization
 class Regexp
 
   # Deserializes JSON string by constructing new Regexp object with source

--- a/lib/json/add/struct.rb
+++ b/lib/json/add/struct.rb
@@ -2,7 +2,6 @@ unless defined?(::JSON::JSON_LOADED) and ::JSON::JSON_LOADED
   require 'json'
 end
 
-# Struct serialization/deserialization
 class Struct
 
   # Deserializes JSON string by constructing new Struct object with values

--- a/lib/json/add/symbol.rb
+++ b/lib/json/add/symbol.rb
@@ -2,7 +2,6 @@ unless defined?(::JSON::JSON_LOADED) and ::JSON::JSON_LOADED
   require 'json'
 end
 
-# Symbol serialization/deserialization
 class Symbol
   # Returns a hash, that will be turned into a JSON object and represent this
   # object.

--- a/lib/json/add/time.rb
+++ b/lib/json/add/time.rb
@@ -2,7 +2,6 @@ unless defined?(::JSON::JSON_LOADED) and ::JSON::JSON_LOADED
   require 'json'
 end
 
-# Time serialization/deserialization
 class Time
 
   # Deserializes JSON string by converting time since epoch to Time


### PR DESCRIPTION
_(Previously submitted to MRI's bug tracker, as https://bugs.ruby-lang.org/issues/12255)._

This patch removes some comments that otherwise would appear in MRI's docs of the affected core classes.

E.g. for `Exception`

```
$ ri Exception
Descendants of class Exception are used to [...]

[snipped class documentation]

Exception serialization/deserialization        <- does not belong here!
-------------------------------------------
Class methods:

[snip]
```

Or see for example http://docs.ruby-lang.org/en/trunk/Exception.html, where the same comment appears just above the "Public Class Methods" section.