### PR TITLE
Suppress a warning

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -951,6 +951,7 @@ static VALUE cState_generate(VALUE self, VALUE obj)
 {
     VALUE result = cState_partial_generate(self, obj);
     GET_STATE(self);
+    (void)state;
     return result;
 }
 


### PR DESCRIPTION
Suppress a unused-but-set-variable warning by gcc.