### PR TITLE
Fix inconsistency usage for assertion methods

### DIFF
--- a/tests/json_common_interface_test.rb
+++ b/tests/json_common_interface_test.rb
@@ -47,7 +47,7 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
   end
 
   def test_deep_const_get
-    assert_raises(ArgumentError) { JSON.deep_const_get('Nix::Da') }
+    assert_raise(ArgumentError) { JSON.deep_const_get('Nix::Da') }
     assert_equal File::SEPARATOR, JSON.deep_const_get('File::SEPARATOR')
   end
 
@@ -93,8 +93,8 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
 
   def test_load_null
     assert_equal nil, JSON.load(nil, nil, :allow_blank => true)
-    assert_raises(TypeError) { JSON.load(nil, nil, :allow_blank => false) }
-    assert_raises(JSON::ParserError) { JSON.load('', nil, :allow_blank => false) }
+    assert_raise(TypeError) { JSON.load(nil, nil, :allow_blank => false) }
+    assert_raise(JSON::ParserError) { JSON.load('', nil, :allow_blank => false) }
   end
 
   def test_dump


### PR DESCRIPTION
ruby core test suites does not have `assert_raises` method. I replaced these assertions to use `assert_raise`