### PR TITLE
No Bignum

### DIFF
--- a/tests/json_generator_test.rb
+++ b/tests/json_generator_test.rb
@@ -277,12 +277,13 @@ EOT
   if defined?(JSON::Ext::Generator)
     def test_broken_bignum # [ruby-core:38867]
       pid = fork do
-        Bignum.class_eval do
+        x = 1 << 64
+        x.class.class_eval do
           def to_s
           end
         end
         begin
-          JSON::Ext::Generator::State.new.generate(1<<64)
+          JSON::Ext::Generator::State.new.generate(x)
           exit 1
         rescue TypeError
           exit 0


### PR DESCRIPTION
Get rid of use of Bignum, which will be deprecated since ruby 2.4.