### PR TITLE
Restore ruby 1.8 compatibility to json v1.8 branch

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -889,7 +889,7 @@ static void generate_json(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *s
         generate_json_true(buffer, Vstate, state, obj);
     } else if (FIXNUM_P(obj)) {
         generate_json_fixnum(buffer, Vstate, state, obj);
-    } else if (RB_TYPE_P(obj, T_BIGNUM)) {
+    } else if (rb_type(obj) == T_BIGNUM) {
         generate_json_bignum(buffer, Vstate, state, obj);
     } else if (klass == rb_cFloat) {
         generate_json_float(buffer, Vstate, state, obj);


### PR DESCRIPTION
RB_TYPE_P is not available in ruby 1.8.7.  While json 2.0+ dropped
ruby 1.8 compatibility, the required_ruby_version in the gemspec
is not set (commented out), so the expectation is a tiny release
would not change which ruby versions are supported.