### PR TITLE
Actually test BigDecimal parsing.

### DIFF
--- a/tests/json_parser_test.rb
+++ b/tests/json_parser_test.rb
@@ -108,6 +108,11 @@ class JSONParserTest < Test::Unit::TestCase
     assert_equal -1.0/0, parse('-Infinity', :allow_nan => true)
   end
 
+  def test_parse_bigdecimals
+    assert_equal(BigDecimal,                                 JSON.parse('{"foo": 9.01234567890123456789}', decimal_class: BigDecimal)["foo"].class)
+    assert_equal(BigDecimal.new("0.901234567890123456789E1"),JSON.parse('{"foo": 9.01234567890123456789}', decimal_class: BigDecimal)["foo"]      )
+  end
+
   if Array.method_defined?(:permutation)
     def test_parse_more_complex_arrays
       a = [ nil, false, true, "foßbar", [ "n€st€d", true ], { "nested" => true, "n€ßt€ð2" => {} }]


### PR DESCRIPTION
Parsing using a different `decimal_class` is implemented, but tests are lacking. This pull requests tests parsing using BigDecimal as a `decimal_class`.

Note that the tests currently fail due to bug #320.