### PR TITLE
Fixed json_create example to use create_additions = true

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Now it possible to serialise/deserialise ranges as well:
 ```ruby
  json = JSON.generate [1, 2, {"a"=>3.141}, false, true, nil, 4..10]
  # => "[1,2,{\"a\":3.141},false,true,null,{\"json_class\":\"Range\",\"data\":[4,10,false]}]"
- JSON.parse json
+ JSON.parse json, :create_additions => true
  # => [1, 2, {"a"=>3.141}, false, true, nil, 4..10]
 ```
 


### PR DESCRIPTION
The example doesn't work OOTB, since this flag is _not enabled_ by default.

(Even with this change in place, I cannot get additions to work with the `Range` class. For custom objects it works though, I tested with the example from the `json_addition_test.rb` - that's where I got the working approach.)