### PR TITLE
Added missing bigdecimal for its test

### DIFF
--- a/tests/json_parser_test.rb
+++ b/tests/json_parser_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 require 'stringio'
 require 'tempfile'
 require 'ostruct'
+require 'bigdecimal'
 
 class JSONParserTest < Test::Unit::TestCase
   include JSON


### PR DESCRIPTION
It's a backport patch for test preparation.

https://github.com/ruby/ruby/commit/ab8e756de0f88f1841510a4043558c0f4d28c5cc

`test_parse_bigdecimals` needs explicitly a declaration of bigdecimal.