### PR TITLE
update travis config for ruby versions and fix 1.9.3 failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,15 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3.3
-  - 2.4.1
+  - 2.3.5
+  - 2.4.2
   - jruby
   - ruby-head
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: 1.9.3
 script: "bundle exec rake"
 sudo: false
+
+before_install:
+  - gem install bundler


### PR DESCRIPTION
Updated ruby versions to latest for CI.

Adding the before_install block to install latest bundler should fix the build issues with ruby 1.9.3 and remove the need to allow that failure.