### PR TITLE
Improve JSON.parse() performance

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -111,7 +111,7 @@ enum {JSON_object_error = 0};
 enum {JSON_object_en_main = 1};
 
 
-#line 166 "parser.rl"
+#line 167 "parser.rl"
 
 
 static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -132,7 +132,7 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
 	cs = JSON_object_start;
 	}
 
-#line 181 "parser.rl"
+#line 182 "parser.rl"
 
 #line 138 "parser.c"
 	{
@@ -162,7 +162,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 148 "parser.rl"
+#line 149 "parser.rl"
 	{
         char *np;
         json->parsing_name = 1;
@@ -250,6 +250,7 @@ tr11:
             p--; {p++; cs = 9; goto _out;}
         } else {
             if (NIL_P(json->object_class)) {
+                OBJ_FREEZE(last_name);
                 rb_hash_aset(*result, last_name, v);
             } else {
                 rb_funcall(*result, i_aset, 2, last_name, v);
@@ -262,7 +263,7 @@ st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 266 "parser.c"
+#line 267 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st9;
 		case 32: goto st9;
@@ -351,14 +352,14 @@ case 18:
 		goto st9;
 	goto st18;
 tr4:
-#line 156 "parser.rl"
+#line 157 "parser.rl"
 	{ p--; {p++; cs = 27; goto _out;} }
 	goto st27;
 st27:
 	if ( ++p == pe )
 		goto _test_eof27;
 case 27:
-#line 362 "parser.c"
+#line 363 "parser.c"
 	goto st0;
 st19:
 	if ( ++p == pe )
@@ -456,7 +457,7 @@ case 26:
 	_out: {}
 	}
 
-#line 182 "parser.rl"
+#line 183 "parser.rl"
 
     if (cs >= JSON_object_first_final) {
         if (json->create_additions) {
@@ -481,7 +482,7 @@ case 26:
 
 
 
-#line 485 "parser.c"
+#line 486 "parser.c"
 enum {JSON_value_start = 1};
 enum {JSON_value_first_final = 29};
 enum {JSON_value_error = 0};
@@ -489,7 +490,7 @@ enum {JSON_value_error = 0};
 enum {JSON_value_en_main = 1};
 
 
-#line 282 "parser.rl"
+#line 283 "parser.rl"
 
 
 static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -497,14 +498,14 @@ static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 501 "parser.c"
+#line 502 "parser.c"
 	{
 	cs = JSON_value_start;
 	}
 
-#line 289 "parser.rl"
+#line 290 "parser.rl"
 
-#line 508 "parser.c"
+#line 509 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -538,14 +539,14 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 234 "parser.rl"
+#line 235 "parser.rl"
 	{
         char *np = JSON_parse_string(json, p, pe, result);
         if (np == NULL) { p--; {p++; cs = 29; goto _out;} } else {p = (( np))-1;}
     }
 	goto st29;
 tr3:
-#line 239 "parser.rl"
+#line 240 "parser.rl"
 	{
         char *np;
         if(pe > p + 8 && !strncmp(MinusInfinity, p, 9)) {
@@ -565,7 +566,7 @@ tr3:
     }
 	goto st29;
 tr7:
-#line 257 "parser.rl"
+#line 258 "parser.rl"
 	{
         char *np;
         np = JSON_parse_array(json, p, pe, result, current_nesting + 1);
@@ -573,7 +574,7 @@ tr7:
     }
 	goto st29;
 tr11:
-#line 263 "parser.rl"
+#line 264 "parser.rl"
 	{
         char *np;
         np =  JSON_parse_object(json, p, pe, result, current_nesting + 1);
@@ -581,7 +582,7 @@ tr11:
     }
 	goto st29;
 tr25:
-#line 227 "parser.rl"
+#line 228 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CInfinity;
@@ -591,7 +592,7 @@ tr25:
     }
 	goto st29;
 tr27:
-#line 220 "parser.rl"
+#line 221 "parser.rl"
 	{
         if (json->allow_nan) {
             *result = CNaN;
@@ -601,19 +602,19 @@ tr27:
     }
 	goto st29;
 tr31:
-#line 214 "parser.rl"
+#line 215 "parser.rl"
 	{
         *result = Qfalse;
     }
 	goto st29;
 tr34:
-#line 211 "parser.rl"
+#line 212 "parser.rl"
 	{
         *result = Qnil;
     }
 	goto st29;
 tr37:
-#line 217 "parser.rl"
+#line 218 "parser.rl"
 	{
         *result = Qtrue;
     }
@@ -622,9 +623,9 @@ st29:
 	if ( ++p == pe )
 		goto _test_eof29;
 case 29:
-#line 269 "parser.rl"
+#line 270 "parser.rl"
 	{ p--; {p++; cs = 29; goto _out;} }
-#line 628 "parser.c"
+#line 629 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st29;
 		case 32: goto st29;
@@ -865,7 +866,7 @@ case 28:
 	_out: {}
 	}
 
-#line 290 "parser.rl"
+#line 291 "parser.rl"
 
     if (cs >= JSON_value_first_final) {
         return p;
@@ -875,7 +876,7 @@ case 28:
 }
 
 
-#line 879 "parser.c"
+#line 880 "parser.c"
 enum {JSON_integer_start = 1};
 enum {JSON_integer_first_final = 3};
 enum {JSON_integer_error = 0};
@@ -883,7 +884,7 @@ enum {JSON_integer_error = 0};
 enum {JSON_integer_en_main = 1};
 
 
-#line 306 "parser.rl"
+#line 307 "parser.rl"
 
 
 static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -891,15 +892,15 @@ static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *res
     int cs = EVIL;
 
 
-#line 895 "parser.c"
+#line 896 "parser.c"
 	{
 	cs = JSON_integer_start;
 	}
 
-#line 313 "parser.rl"
+#line 314 "parser.rl"
     json->memo = p;
 
-#line 903 "parser.c"
+#line 904 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -933,14 +934,14 @@ case 3:
 		goto st0;
 	goto tr4;
 tr4:
-#line 303 "parser.rl"
+#line 304 "parser.rl"
 	{ p--; {p++; cs = 4; goto _out;} }
 	goto st4;
 st4:
 	if ( ++p == pe )
 		goto _test_eof4;
 case 4:
-#line 944 "parser.c"
+#line 945 "parser.c"
 	goto st0;
 st5:
 	if ( ++p == pe )
@@ -959,7 +960,7 @@ case 5:
 	_out: {}
 	}
 
-#line 315 "parser.rl"
+#line 316 "parser.rl"
 
     if (cs >= JSON_integer_first_final) {
         long len = p - json->memo;
@@ -974,7 +975,7 @@ case 5:
 }
 
 
-#line 978 "parser.c"
+#line 979 "parser.c"
 enum {JSON_float_start = 1};
 enum {JSON_float_first_final = 8};
 enum {JSON_float_error = 0};
@@ -982,7 +983,7 @@ enum {JSON_float_error = 0};
 enum {JSON_float_en_main = 1};
 
 
-#line 340 "parser.rl"
+#line 341 "parser.rl"
 
 
 static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -990,15 +991,15 @@ static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 994 "parser.c"
+#line 995 "parser.c"
 	{
 	cs = JSON_float_start;
 	}
 
-#line 347 "parser.rl"
+#line 348 "parser.rl"
     json->memo = p;
 
-#line 1002 "parser.c"
+#line 1003 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1056,14 +1057,14 @@ case 8:
 		goto st0;
 	goto tr9;
 tr9:
-#line 334 "parser.rl"
+#line 335 "parser.rl"
 	{ p--; {p++; cs = 9; goto _out;} }
 	goto st9;
 st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 1067 "parser.c"
+#line 1068 "parser.c"
 	goto st0;
 st5:
 	if ( ++p == pe )
@@ -1124,7 +1125,7 @@ case 7:
 	_out: {}
 	}
 
-#line 349 "parser.rl"
+#line 350 "parser.rl"
 
     if (cs >= JSON_float_first_final) {
         long len = p - json->memo;
@@ -1146,7 +1147,7 @@ case 7:
 
 
 
-#line 1150 "parser.c"
+#line 1151 "parser.c"
 enum {JSON_array_start = 1};
 enum {JSON_array_first_final = 17};
 enum {JSON_array_error = 0};
@@ -1154,7 +1155,7 @@ enum {JSON_array_error = 0};
 enum {JSON_array_en_main = 1};
 
 
-#line 398 "parser.rl"
+#line 399 "parser.rl"
 
 
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -1168,14 +1169,14 @@ static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *resul
     *result = NIL_P(array_class) ? rb_ary_new() : rb_class_new_instance(0, 0, array_class);
 
 
-#line 1172 "parser.c"
+#line 1173 "parser.c"
 	{
 	cs = JSON_array_start;
 	}
 
-#line 411 "parser.rl"
+#line 412 "parser.rl"
 
-#line 1179 "parser.c"
+#line 1180 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1214,7 +1215,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 375 "parser.rl"
+#line 376 "parser.rl"
 	{
         VALUE v = Qnil;
         char *np = JSON_parse_value(json, p, pe, &v, current_nesting);
@@ -1234,7 +1235,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 1238 "parser.c"
+#line 1239 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st3;
 		case 32: goto st3;
@@ -1334,14 +1335,14 @@ case 12:
 		goto st3;
 	goto st12;
 tr4:
-#line 390 "parser.rl"
+#line 391 "parser.rl"
 	{ p--; {p++; cs = 17; goto _out;} }
 	goto st17;
 st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1345 "parser.c"
+#line 1346 "parser.c"
 	goto st0;
 st13:
 	if ( ++p == pe )
@@ -1397,7 +1398,7 @@ case 16:
 	_out: {}
 	}
 
-#line 412 "parser.rl"
+#line 413 "parser.rl"
 
     if(cs >= JSON_array_first_final) {
         return p + 1;
@@ -1486,7 +1487,7 @@ static VALUE json_string_unescape(VALUE result, char *string, char *stringEnd)
 }
 
 
-#line 1490 "parser.c"
+#line 1491 "parser.c"
 enum {JSON_string_start = 1};
 enum {JSON_string_first_final = 8};
 enum {JSON_string_error = 0};
@@ -1494,7 +1495,7 @@ enum {JSON_string_error = 0};
 enum {JSON_string_en_main = 1};
 
 
-#line 519 "parser.rl"
+#line 520 "parser.rl"
 
 
 static int
@@ -1516,15 +1517,15 @@ static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *resu
 
     *result = rb_str_buf_new(0);
 
-#line 1520 "parser.c"
+#line 1521 "parser.c"
 	{
 	cs = JSON_string_start;
 	}
 
-#line 540 "parser.rl"
+#line 541 "parser.rl"
     json->memo = p;
 
-#line 1528 "parser.c"
+#line 1529 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1549,7 +1550,7 @@ case 2:
 		goto st0;
 	goto st2;
 tr2:
-#line 505 "parser.rl"
+#line 506 "parser.rl"
 	{
         *result = json_string_unescape(*result, json->memo + 1, p);
         if (NIL_P(*result)) {
@@ -1560,14 +1561,14 @@ tr2:
             {p = (( p + 1))-1;}
         }
     }
-#line 516 "parser.rl"
+#line 517 "parser.rl"
 	{ p--; {p++; cs = 8; goto _out;} }
 	goto st8;
 st8:
 	if ( ++p == pe )
 		goto _test_eof8;
 case 8:
-#line 1571 "parser.c"
+#line 1572 "parser.c"
 	goto st0;
 st3:
 	if ( ++p == pe )
@@ -1643,7 +1644,7 @@ case 7:
 	_out: {}
 	}
 
-#line 542 "parser.rl"
+#line 543 "parser.rl"
 
     if (json->create_additions && RTEST(match_string = json->match_string)) {
           VALUE klass;
@@ -1830,7 +1831,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 
-#line 1834 "parser.c"
+#line 1835 "parser.c"
 enum {JSON_start = 1};
 enum {JSON_first_final = 10};
 enum {JSON_error = 0};
@@ -1838,7 +1839,7 @@ enum {JSON_error = 0};
 enum {JSON_en_main = 1};
 
 
-#line 742 "parser.rl"
+#line 743 "parser.rl"
 
 
 /*
@@ -1855,16 +1856,16 @@ static VALUE cParser_parse(VALUE self)
   GET_PARSER;
 
 
-#line 1859 "parser.c"
+#line 1860 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 758 "parser.rl"
+#line 759 "parser.rl"
   p = json->source;
   pe = p + json->len;
 
-#line 1868 "parser.c"
+#line 1869 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1898,7 +1899,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 734 "parser.rl"
+#line 735 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -1908,7 +1909,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 1912 "parser.c"
+#line 1913 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -1997,7 +1998,7 @@ case 9:
 	_out: {}
 	}
 
-#line 761 "parser.rl"
+#line 762 "parser.rl"
 
   if (cs >= JSON_first_final && p == pe) {
     return result;

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -137,6 +137,7 @@ static ID i_json_creatable_p, i_json_create, i_create_id, i_create_additions,
             fhold; fbreak;
         } else {
             if (NIL_P(json->object_class)) {
+                OBJ_FREEZE(last_name);
                 rb_hash_aset(*result, last_name, v);
             } else {
                 rb_funcall(*result, i_aset, 2, last_name, v);


### PR DESCRIPTION
When use non-frozen string as hash key with `rb_hash_aset()`, it will duplicate and freeze the string internally.
To avoid duplicate and freeze, this patch will give a frozen string in `rb_hash_aset()`.

FYI)
If you use string as hash key, hash object always might have frozen string as key.

```ruby
irb(main):001:0> hash = { "foo" => 42 }
=> {"foo"=>42}
irb(main):002:0> hash.keys[0].frozen?
=> true
```

This patches will be 15 % faster.

## Environment
* Machine : MacBook (Retina, 12-inch, 2017)
* OS : macOS 10.13.3
* Compiler : Apple LLVM version 9.1.0 (clang-902.0.31)
* Ruby : ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-darwin17]

## Before
```
$ ruby bench.rb
Warming up --------------------------------------
                json    14.000  i/100ms
Calculating -------------------------------------
                json    144.882  (± 1.4%) i/s -    728.000  in   5.025682s
```

## After
```
$ ruby bench.rb
Warming up --------------------------------------
                json    16.000  i/100ms
Calculating -------------------------------------
                json    165.608  (± 1.8%) i/s -    832.000  in   5.025367s
```

## Test code
```ruby
require 'json'
require 'objspace'
require 'securerandom'
require 'benchmark/ips'

obj = []

1000.times do |i|
  obj << {
    "id": i,
    "uuid": SecureRandom.uuid,
    "created_at": Time.now
  }
end

json = obj.to_json

Benchmark.ips do |x|
  x.report "json" do |iter|
    count = 0
    while count < iter
      JSON.parse(json)
      count += 1
    end
  end
end
```