### PR TITLE
Improve JSON.generate() performance

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -740,7 +740,7 @@ json_object_i(VALUE key, VALUE val, VALUE _arg)
     long delim2_len = FBUFFER_LEN(state->object_delim2);
     long depth = state->depth;
     int j;
-    VALUE key_to_s;
+    VALUE klass, key_to_s;
 
     if (arg->iter > 0) fbuffer_append(buffer, delim, delim_len);
     if (object_nl) {
@@ -752,7 +752,14 @@ json_object_i(VALUE key, VALUE val, VALUE _arg)
         }
     }
 
-    key_to_s = rb_funcall(key, i_to_s, 0);
+    klass = CLASS_OF(key);
+    if (klass == rb_cString) {
+        key_to_s = key;
+    } else if (klass == rb_cSymbol) {
+        key_to_s = rb_id2str(SYM2ID(key));
+    } else {
+        key_to_s = rb_funcall(key, i_to_s, 0);
+    }
     Check_Type(key_to_s, T_STRING);
     generate_json(buffer, Vstate, state, key_to_s);
     fbuffer_append(buffer, delim2, delim2_len);

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -715,6 +715,53 @@ static VALUE cState_aset(VALUE self, VALUE name, VALUE value)
     return Qnil;
 }
 
+struct hash_foreach_arg {
+    FBuffer *buffer;
+    JSON_Generator_State *state;
+    VALUE Vstate;
+    int iter;
+};
+
+static int
+json_object_i(VALUE key, VALUE val, VALUE _arg)
+{
+    struct hash_foreach_arg *arg = (struct hash_foreach_arg *)_arg;
+    FBuffer *buffer = arg->buffer;
+    JSON_Generator_State *state = arg->state;
+    VALUE Vstate = arg->Vstate;
+
+    char *object_nl = state->object_nl;
+    long object_nl_len = state->object_nl_len;
+    char *indent = state->indent;
+    long indent_len = state->indent_len;
+    char *delim = FBUFFER_PTR(state->object_delim);
+    long delim_len = FBUFFER_LEN(state->object_delim);
+    char *delim2 = FBUFFER_PTR(state->object_delim2);
+    long delim2_len = FBUFFER_LEN(state->object_delim2);
+    long depth = state->depth;
+    int j;
+    VALUE key_to_s;
+
+    if (arg->iter > 0) fbuffer_append(buffer, delim, delim_len);
+    if (object_nl) {
+        fbuffer_append(buffer, object_nl, object_nl_len);
+    }
+    if (indent) {
+        for (j = 0; j < depth; j++) {
+            fbuffer_append(buffer, indent, indent_len);
+        }
+    }
+
+    key_to_s = rb_funcall(key, i_to_s, 0);
+    Check_Type(key_to_s, T_STRING);
+    generate_json(buffer, Vstate, state, key_to_s);
+    fbuffer_append(buffer, delim2, delim2_len);
+    generate_json(buffer, Vstate, state, val);
+
+    arg->iter++;
+    return ST_CONTINUE;
+}
+
 static void generate_json_object(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj)
 {
     char *object_nl = state->object_nl;
@@ -722,36 +769,22 @@ static void generate_json_object(FBuffer *buffer, VALUE Vstate, JSON_Generator_S
     char *indent = state->indent;
     long indent_len = state->indent_len;
     long max_nesting = state->max_nesting;
-    char *delim = FBUFFER_PTR(state->object_delim);
-    long delim_len = FBUFFER_LEN(state->object_delim);
-    char *delim2 = FBUFFER_PTR(state->object_delim2);
-    long delim2_len = FBUFFER_LEN(state->object_delim2);
     long depth = ++state->depth;
-    int i, j;
-    VALUE key, key_to_s, keys;
+    int j;
+    struct hash_foreach_arg arg;
+
     if (max_nesting != 0 && depth > max_nesting) {
         fbuffer_free(buffer);
         rb_raise(eNestingError, "nesting of %ld is too deep", --state->depth);
     }
     fbuffer_append_char(buffer, '{');
-    keys = rb_funcall(obj, i_keys, 0);
-    for(i = 0; i < RARRAY_LEN(keys); i++) {
-        if (i > 0) fbuffer_append(buffer, delim, delim_len);
-        if (object_nl) {
-            fbuffer_append(buffer, object_nl, object_nl_len);
-        }
-        if (indent) {
-            for (j = 0; j < depth; j++) {
-                fbuffer_append(buffer, indent, indent_len);
-            }
-        }
-        key = rb_ary_entry(keys, i);
-        key_to_s = rb_funcall(key, i_to_s, 0);
-        Check_Type(key_to_s, T_STRING);
-        generate_json(buffer, Vstate, state, key_to_s);
-        fbuffer_append(buffer, delim2, delim2_len);
-        generate_json(buffer, Vstate, state, rb_hash_aref(obj, key));
-    }
+
+    arg.buffer = buffer;
+    arg.state = state;
+    arg.Vstate = Vstate;
+    arg.iter = 0;
+    rb_hash_foreach(obj, json_object_i, (VALUE)&arg);
+
     depth = --state->depth;
     if (object_nl) {
         fbuffer_append(buffer, object_nl, object_nl_len);

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -846,7 +846,7 @@ static void generate_json_string(FBuffer *buffer, VALUE Vstate, JSON_Generator_S
 {
     fbuffer_append_char(buffer, '"');
 #ifdef HAVE_RUBY_ENCODING_H
-    obj = rb_funcall(obj, i_encode, 1, CEncoding_UTF_8);
+    obj = rb_str_encode(obj, CEncoding_UTF_8, 0, Qnil);
 #endif
     if (state->ascii_only) {
         convert_UTF8_to_JSON_ASCII(buffer, obj);

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -846,7 +846,9 @@ static void generate_json_string(FBuffer *buffer, VALUE Vstate, JSON_Generator_S
 {
     fbuffer_append_char(buffer, '"');
 #ifdef HAVE_RUBY_ENCODING_H
-    obj = rb_str_encode(obj, CEncoding_UTF_8, 0, Qnil);
+    if (!rb_enc_str_asciicompat_p(obj)) {
+        obj = rb_str_encode(obj, CEncoding_UTF_8, 0, Qnil);
+    }
 #endif
     if (state->ascii_only) {
         convert_UTF8_to_JSON_ASCII(buffer, obj);


### PR DESCRIPTION
This pull request adds some shortcut to convert Object to json.
JSON.generate() performance will be 3.53 times faster by this.

## Environment
* Machine : MacBook (Retina, 12-inch, 2017)
* OS : macOS 10.13.3
* Compiler : Apple LLVM version 9.1.0 (clang-902.0.31)
* Ruby : ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-darwin17]

## Before
```
$ ruby bench_json_generate2.rb
Warming up --------------------------------------
                json    54.000  i/100ms
                yajl    63.000  i/100ms
                  oj   286.000  i/100ms
Calculating -------------------------------------
                json    552.420  (± 1.3%) i/s -      2.808k in   5.083937s
                yajl    640.489  (± 1.7%) i/s -      3.213k in   5.017937s
                  oj      2.961k (± 4.1%) i/s -     14.872k in   5.032250s
```

## After
```
$ ruby bench_json_generate2.rb
Warming up --------------------------------------
                json   176.000  i/100ms
                yajl    50.000  i/100ms
                  oj   234.000  i/100ms
Calculating -------------------------------------
                json      1.949k (± 4.3%) i/s -      9.856k in   5.068917s
                yajl    643.232  (± 1.4%) i/s -      3.250k in   5.053518s
                  oj      2.970k (± 4.2%) i/s -     14.976k in   5.053368s
```

![graph](https://user-images.githubusercontent.com/199156/37039999-2cdf69f6-219c-11e8-9b5b-cd78bf93407a.png)

## Benchmark code
```ruby
require 'json'
require 'oj'
require 'yajl'
require 'benchmark/ips'

obj = []

1000.times do |i|
  obj << {
    "id" => i,
    :age => 42,
  }
end

Benchmark.ips do |x|
  x.report("json") { JSON.generate(obj) }
  x.report("yajl") { Yajl::Encoder.encode(obj, nil) }
  x.report("oj")   { Oj.dump(obj) }
end
```