### PR TITLE
Add :nodoc: for GeneratorMethods

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -324,6 +324,76 @@ static char *fstrndup(const char *ptr, unsigned long len) {
  *
  */
 
+/* Explanation of the following: that's the only way to not pollute
+ * standard library's docs with GeneratorMethods::<ClassName> which
+ * are uninformative and take a large place in a list of classes
+ */
+
+/*
+ * Document-module: JSON::Ext::Generator::GeneratorMethods
+ * :nodoc:
+ */
+
+/*
+ * Document-module: JSON::Ext::Generator::GeneratorMethods::Array
+ * :nodoc:
+ */
+
+/*
+ * Document-module: JSON::Ext::Generator::GeneratorMethods::Bignum
+ * :nodoc:
+ */
+
+/*
+ * Document-module: JSON::Ext::Generator::GeneratorMethods::FalseClass
+ * :nodoc:
+ */
+
+/*
+ * Document-module: JSON::Ext::Generator::GeneratorMethods::Fixnum
+ * :nodoc:
+ */
+
+/*
+ * Document-module: JSON::Ext::Generator::GeneratorMethods::Float
+ * :nodoc:
+ */
+
+/*
+ * Document-module: JSON::Ext::Generator::GeneratorMethods::Hash
+ * :nodoc:
+ */
+
+/*
+ * Document-module: JSON::Ext::Generator::GeneratorMethods::Integer
+ * :nodoc:
+ */
+
+/*
+ * Document-module: JSON::Ext::Generator::GeneratorMethods::NilClass
+ * :nodoc:
+ */
+
+/*
+ * Document-module: JSON::Ext::Generator::GeneratorMethods::Object
+ * :nodoc:
+ */
+
+/*
+ * Document-module: JSON::Ext::Generator::GeneratorMethods::String
+ * :nodoc:
+ */
+
+/*
+ * Document-module: JSON::Ext::Generator::GeneratorMethods::String::Extend
+ * :nodoc:
+ */
+
+/*
+ * Document-module: JSON::Ext::Generator::GeneratorMethods::TrueClass
+ * :nodoc:
+ */
+
 /*
  * call-seq: to_json(state = nil)
  *


### PR DESCRIPTION
Explanation: currently, stdlib docs list of classes look like this on docs.ruby-lang.org:
![image](https://user-images.githubusercontent.com/129656/37169230-01e40016-2310-11e8-8c13-80f725923c03.png)

This is unnecessary pollution, as `GeneratorMethods`, in fact, is detail of implementation, and every module just contains the same, briefly documented, `to_json` method.

(I am not sure if there is a shorter way to "dedocument" modules for C extension, so far that's the only way I've found)

