### PR TITLE
Fix for bigdecimal updates

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -91,12 +91,13 @@ static int convert_UTF32_to_UTF8(char *buf, UTF32 ch)
 
 static VALUE mJSON, mExt, cParser, eParserError, eNestingError;
 static VALUE CNaN, CInfinity, CMinusInfinity;
+static VALUE cBigDecimal = Qundef;
 
 static ID i_json_creatable_p, i_json_create, i_create_id, i_create_additions,
           i_chr, i_max_nesting, i_allow_nan, i_symbolize_names,
           i_object_class, i_array_class, i_decimal_class, i_key_p,
           i_deep_const_get, i_match, i_match_string, i_aset, i_aref,
-          i_leftshift, i_new;
+          i_leftshift, i_new, i_BigDecimal;
 
 
 #line 125 "parser.rl"
@@ -985,6 +986,18 @@ enum {JSON_float_en_main = 1};
 #line 340 "parser.rl"
 
 
+static int is_bigdecimal_class(VALUE obj)
+{
+    if (cBigDecimal == Qundef) {
+        if (rb_const_defined(rb_cObject, i_BigDecimal)) {
+            cBigDecimal = rb_const_get_at(rb_cObject, i_BigDecimal);
+        } else {
+            return 0;
+        }
+    }
+    return obj == cBigDecimal;
+}
+
 static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *result)
 {
     int cs = EVIL;
@@ -1136,7 +1149,11 @@ case 7:
         } else {
           VALUE text;
           text = rb_str_new2(FBUFFER_PTR(json->fbuffer));
-          *result = rb_funcall(json->decimal_class, i_new, 1, text);
+          if (is_bigdecimal_class(json->decimal_class)) {
+            *result = rb_funcall(Qnil, i_BigDecimal, 1, text);
+          } else {
+            *result = rb_funcall(json->decimal_class, i_new, 1, text);
+          }
         }
         return p + 1;
     } else {

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -89,12 +89,13 @@ static int convert_UTF32_to_UTF8(char *buf, UTF32 ch)
 
 static VALUE mJSON, mExt, cParser, eParserError, eNestingError;
 static VALUE CNaN, CInfinity, CMinusInfinity;
+static VALUE cBigDecimal = Qundef;
 
 static ID i_json_creatable_p, i_json_create, i_create_id, i_create_additions,
           i_chr, i_max_nesting, i_allow_nan, i_symbolize_names,
           i_object_class, i_array_class, i_decimal_class, i_key_p,
           i_deep_const_get, i_match, i_match_string, i_aset, i_aref,
-          i_leftshift, i_new;
+          i_leftshift, i_new, i_BigDecimal;
 
 %%{
     machine JSON_common;
@@ -339,6 +340,18 @@ static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *res
              )  (^[0-9Ee.\-]? @exit );
 }%%
 
+static int is_bigdecimal_class(VALUE obj)
+{
+     if (cBigDecimal == Qundef) {
+         if (rb_const_defined(rb_cObject, i_BigDecimal)) {
+             cBigDecimal = rb_const_get_at(rb_cObject, i_BigDecimal);
+         } else {
+             return 0;
+         }
+     }
+     return obj == cBigDecimal;
+}
+
 static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *result)
 {
     int cs = EVIL;
@@ -357,7 +370,11 @@ static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *resul
         } else {
           VALUE text;
           text = rb_str_new2(FBUFFER_PTR(json->fbuffer));
-          *result = rb_funcall(json->decimal_class, i_new, 1, text);
+          if (is_bigdecimal_class(json->decimal_class)) {
+            *result = rb_funcall(Qnil, i_BigDecimal, 1, text);
+          } else {
+            *result = rb_funcall(json->decimal_class, i_new, 1, text);
+          }
         }
         return p + 1;
     } else {


### PR DESCRIPTION
`BigDecimal.new` is no longer available from bigdecimal-1.4.0.
This pull request removes the dependencies that method.