### PR TITLE
Pass args all #to_json in json/add/*.

### DIFF
--- a/lib/json/add/bigdecimal.rb
+++ b/lib/json/add/bigdecimal.rb
@@ -23,7 +23,7 @@ class BigDecimal
   end
 
   # return the JSON value
-  def to_json(*)
-    as_json.to_json
+  def to_json(*args)
+    as_json.to_json(*args)
   end
 end

--- a/lib/json/add/complex.rb
+++ b/lib/json/add/complex.rb
@@ -23,7 +23,7 @@ class Complex
   end
 
   # Stores class name (Complex) along with real value <tt>r</tt> and imaginary value <tt>i</tt> as JSON string
-  def to_json(*)
-    as_json.to_json
+  def to_json(*args)
+    as_json.to_json(*args)
   end
 end

--- a/lib/json/add/rational.rb
+++ b/lib/json/add/rational.rb
@@ -22,7 +22,7 @@ class Rational
   end
 
   # Stores class name (Rational) along with numerator value <tt>n</tt> and denominator value <tt>d</tt> as JSON string
-  def to_json(*)
-    as_json.to_json
+  def to_json(*args)
+    as_json.to_json(*args)
   end
 end

--- a/lib/json/add/regexp.rb
+++ b/lib/json/add/regexp.rb
@@ -24,7 +24,7 @@ class Regexp
 
   # Stores class name (Regexp) with options <tt>o</tt> and source <tt>s</tt>
   # (Regexp or String) as JSON string
-  def to_json(*)
-    as_json.to_json
+  def to_json(*args)
+    as_json.to_json(*args)
   end
 end


### PR DESCRIPTION
Below methods are not passing arguments to #to_json.

* BigDecimal#to_json
* Complex#to_json
* Rational#to_json
* Regexp#to_json

But, for example Date#to_json is passing arguments.

```
require "json/add/core"
require "json/add/complex"

puts Date.today.to_json(space: " ") #=> '{"json_class": "Date","y": 2019,"m": 1,"d": 15,"sg": 2299161.0}'
puts 1i.to_json(space: " ")         #=> '{"json_class":"Complex","r":0,"i":1}'
```

We can pass arguments all #to_json in json/add/* after this PR.

```
require "json/add/core"
require "json/add/complex"

puts Date.today.to_json(space: " ") #=> '{"json_class": "Date","y": 2019,"m": 1,"d": 15,"sg": 2299161.0}'
puts 1i.to_json(space: " ")         #=> '{"json_class": "Complex","r": 0,"i": 1}'
```