### PR TITLE
README: Docs at rubydoc.info, not on rubyforge

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,4 +406,4 @@ The latest version of this library can be downloaded at
 
 Online Documentation should be located at
 
-* http://json.rubyforge.org
+* https://www.rubydoc.info/gems/json


### PR DESCRIPTION
This PR changes the link in the README to the existing rendered documentation.

(RubyForge is closed.)
