### PR TITLE
Fixed unexpected illegal/malformed utf-8 error

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -846,11 +846,20 @@ static void generate_json_array(FBuffer *buffer, VALUE Vstate, JSON_Generator_St
     fbuffer_append_char(buffer, ']');
 }
 
+#ifdef HAVE_RUBY_ENCODING_H
+static int enc_utf8_compatible_p(rb_encoding *enc)
+{
+    if (enc == rb_usascii_encoding()) return 1;
+    if (enc == rb_utf8_encoding()) return 1;
+    return 0;
+}
+#endif
+
 static void generate_json_string(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj)
 {
     fbuffer_append_char(buffer, '"');
 #ifdef HAVE_RUBY_ENCODING_H
-    if (!rb_enc_str_asciicompat_p(obj)) {
+    if (!enc_utf8_compatible_p(rb_enc_get(obj))) {
         obj = rb_str_encode(obj, CEncoding_UTF_8, 0, Qnil);
     }
 #endif

--- a/tests/json_generator_test.rb
+++ b/tests/json_generator_test.rb
@@ -374,4 +374,10 @@ EOT
       assert_equal '["foo"]', JSON.generate([s.new('foo')])
     end
   end
+
+  if defined?(Encoding)
+    def test_nonutf8_encoding
+      assert_equal("\"5\u{b0}\"", "5\xb0".force_encoding("iso-8859-1").to_json)
+    end
+  end
 end


### PR DESCRIPTION
c34d01ff6a18dac04a90b2e0f820cdb1d5c7e1b2 does not consider US-ASCII compatible but non-UTF-8 encodings, and causes an error in RDoc tests.