### PR TITLE
Test with TruffleRuby in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,6 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby
     - rvm: jruby-9.2.7.0
+    - rvm: truffleruby
 script: "bundle exec rake"
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ rvm:
   - ruby-head
   - jruby
   - jruby-9.2.7.0
+  - truffleruby
 matrix:
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
The latest release of JSON (2.3.0) unfortunately broke TruffleRuby 19.3.0, as it used `rb_gc_register_mark_object` which was not yet supported by TruffleRuby: https://github.com/oracle/truffleruby/pull/1856
The TruffleRuby 19.3.1 release fixes it.

It would be useful to test TruffleRuby in CI to notice when it breaks, and if possible avoid breaking it.

I checked and it [fails as expected](https://travis-ci.org/flori/json/jobs/637792223) when using a not-yet-implemented C API function.