### PR TITLE
Add Time#to_json method to improve performance

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -13,7 +13,7 @@ static VALUE mJSON, mExt, mGenerator, cState, mGeneratorMethods, mObject,
 #else
              mFixnum, mBignum,
 #endif
-             mFloat, mString, mString_Extend,
+             mFloat, mTime, mString, mString_Extend,
              mTrueClass, mFalseClass, mNilClass, eGeneratorError,
              eNestingError,
              i_SAFE_STATE_PROTOTYPE;
@@ -464,6 +464,16 @@ static VALUE mBignum_to_json(int argc, VALUE *argv, VALUE self)
 static VALUE mFloat_to_json(int argc, VALUE *argv, VALUE self)
 {
     GENERATE_JSON(float);
+}
+
+/*
+ * call-seq: to_json(*)
+ *
+ * Returns a JSON string representation for this Time object.
+ */
+static VALUE mTime_to_json(int argc, VALUE *argv, VALUE self)
+{
+    GENERATE_JSON(time);
 }
 
 /*
@@ -993,6 +1003,14 @@ static void generate_json_float(FBuffer *buffer, VALUE Vstate, JSON_Generator_St
     fbuffer_append_str(buffer, tmp);
 }
 
+static void generate_json_time(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj)
+{
+    VALUE tmp = rb_funcall(obj, i_to_s, 0);
+    fbuffer_append_char(buffer, '"');
+    fbuffer_append_str(buffer, tmp);
+    fbuffer_append_char(buffer, '"');
+}
+
 static void generate_json(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj)
 {
     VALUE tmp;
@@ -1015,6 +1033,8 @@ static void generate_json(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *s
         generate_json_bignum(buffer, Vstate, state, obj);
     } else if (klass == rb_cFloat) {
         generate_json_float(buffer, Vstate, state, obj);
+    } else if (klass == rb_cTime) {
+        generate_json_time(buffer, Vstate, state, obj);
     } else if (rb_respond_to(obj, i_to_json)) {
         tmp = rb_funcall(obj, i_to_json, 1, Vstate);
         Check_Type(tmp, T_STRING);
@@ -1522,6 +1542,8 @@ void Init_generator(void)
 #endif
     mFloat = rb_define_module_under(mGeneratorMethods, "Float");
     rb_define_method(mFloat, "to_json", mFloat_to_json, -1);
+    mTime = rb_define_module_under(mGeneratorMethods, "Time");
+    rb_define_method(mTime, "to_json", mTime_to_json, -1);
     mString = rb_define_module_under(mGeneratorMethods, "String");
     rb_define_singleton_method(mString, "included", mString_included_s, 1);
     rb_define_method(mString, "to_json", mString_to_json, -1);

--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -130,6 +130,7 @@ static void generate_json_integer(FBuffer *buffer, VALUE Vstate, JSON_Generator_
 static void generate_json_fixnum(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj);
 static void generate_json_bignum(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj);
 static void generate_json_float(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj);
+static void generate_json_time(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj);
 static VALUE cState_partial_generate(VALUE self, VALUE obj);
 static VALUE cState_generate(VALUE self, VALUE obj);
 static VALUE cState_initialize(int argc, VALUE *argv, VALUE self);


### PR DESCRIPTION
When it pass an object containing Time objct as an argument of `JSON.generate`,
the following processes are performed.

1. it will invoke `Time#to_json`
   at https://github.com/flori/json/blob/3d1c6a9246251e382c80dd8d85844c0bbf182da1/ext/json/ext/generator/generator.c#L1019
2. `mObject_to_json` function will be called by invoking `Time#to_json`.
3. it will invoke `Time#to_s`
   at https://github.com/flori/json/blob/3d1c6a9246251e382c80dd8d85844c0bbf182da1/ext/json/ext/generator/generator.c#L576

Seems that it reducde the performance by two Ruby method calls using `rb_funcall`.

This patch adds `generate_json_time` and makes a direct call to `Time#to_s` to reduce `rb_funcall` calling.
The performance is improved by about 20 %.

## Environment
- MacBook Pro (16-inch, 2019)
- macOS 10.15.5
- Intel Core i9 2.4 GHz

### Before
```
Warming up --------------------------------------
       JSON.generate    16.650k i/100ms
        Time.to_json    20.176k i/100ms
Calculating -------------------------------------
       JSON.generate    167.636k (± 0.9%) i/s -    849.150k in   5.065832s
        Time.to_json    200.217k (± 1.2%) i/s -      1.009M in   5.039224s
```

### After
```
Warming up --------------------------------------
       JSON.generate    20.297k i/100ms
        Time.to_json    20.329k i/100ms
Calculating -------------------------------------
       JSON.generate    205.745k (± 1.1%) i/s -      1.035M in   5.031798s
        Time.to_json    203.763k (± 0.7%) i/s -      1.037M in   5.088436s
```

### Test code
```ruby
require 'json'
require 'benchmark/ips'

time = Time.now

Benchmark.ips do |x|
  x.report('JSON.generate') { JSON.generate(time) }
  x.report('Time.to_json') { time.to_json }
end
```