### PR TITLE
Remove generate task for gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -331,4 +331,4 @@ else
 end
 
 desc "Compile in the the source directory"
-task :default => [ :clean, :gemspec, :test ]
+task :default => [ :clean, :test ]

--- a/Rakefile
+++ b/Rakefile
@@ -78,50 +78,6 @@ task :install_ext => [ :compile, :install_pure, :install_ext_really ]
 desc "Installing library (extension)"
 task :install => :install_ext
 
-if defined?(Gem) and defined?(Gem::PackageTask)
-  spec_pure = Gem::Specification.new do |s|
-    s.name = 'json_pure'
-    s.version = PKG_VERSION
-    s.summary = PKG_TITLE
-    s.description = "This is a JSON implementation in pure Ruby."
-
-    s.files = PKG_FILES
-
-    s.require_path = 'lib'
-    s.add_development_dependency 'rake'
-    s.add_development_dependency 'test-unit', '>= 2.0', '< 4.0'
-
-    s.extra_rdoc_files << 'README.md'
-    s.rdoc_options <<
-      '--title' <<  'JSON implemention for ruby' << '--main' << 'README.md'
-    s.test_files.concat Dir['./tests/test_*.rb']
-
-    s.author = "Florian Frank"
-    s.email = "flori@ping.de"
-    s.homepage = "http://flori.github.com/#{PKG_NAME}"
-    s.license = 'Ruby'
-    s.required_ruby_version = '>= 2.0'
-  end
-
-  desc 'Creates a json_pure.gemspec file'
-  task :gemspec_pure => :version do
-    File.open('json_pure.gemspec', 'w') do |gemspec|
-      src = spec_pure.to_ruby
-      src.gsub!(/# stub:.*/, "# This gemspec is generated automatically using `rake gemspec`.\n" \
-                             "# Do not modify directly.")
-      gemspec.write src
-    end
-  end
-
-  Gem::PackageTask.new(spec_pure) do |pkg|
-      pkg.need_tar = true
-      pkg.package_files = PKG_FILES
-  end
-
-  desc 'Alias for gemspec_pure'
-  task :gemspec => [ :gemspec_pure ]
-end
-
 desc m = "Writing version information for #{PKG_VERSION}"
 task :version do
   puts m

--- a/json_pure.gemspec
+++ b/json_pure.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Florian Frank".freeze]
-  s.date = "2020-06-25"
   s.description = "This is a JSON implementation in pure Ruby.".freeze
   s.email = "flori@ping.de".freeze
   s.extra_rdoc_files = ["README.md".freeze]

--- a/json_pure.gemspec
+++ b/json_pure.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "json_pure".freeze
-  s.version = "2.3.0"
+  s.version = File.read("VERSION").chomp
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]

--- a/json_pure.gemspec
+++ b/json_pure.gemspec
@@ -1,6 +1,4 @@
 # -*- encoding: utf-8 -*-
-# This gemspec is generated automatically using `rake gemspec`.
-# Do not modify directly.
 
 Gem::Specification.new do |s|
   s.name = "json_pure".freeze


### PR DESCRIPTION
The only `json_pure` gemspec is auto-generated by Rakefile. It's inconsistency workflow now. 