### PR TITLE
Do not add a relative path to $LOAD_PATH

### DIFF
--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -1,12 +1,12 @@
 case ENV['JSON']
 when 'pure'
-  $:.unshift 'lib'
+  $:.unshift File.join(__dir__, '../lib')
   require 'json/pure'
 when 'ext'
-  $:.unshift 'ext', 'lib'
+  $:.unshift File.join(__dir__, '../ext'), File.join(__dir__, '../lib')
   require 'json/ext'
 else
-  $:.unshift 'ext', 'lib'
+  $:.unshift File.join(__dir__, '../ext'), File.join(__dir__, '../lib')
   require 'json'
 end
 


### PR DESCRIPTION
... because it conflicts with test/ruby/test_m17n.rb in ruby/ruby.

An exception `incompatible character encodings: UTF-8 and UTF-16BE`
occurs when:

* a non-existence relative path is added to $LOAD_PATH,
* ASCII-incompatible encoding is set to default_external, and
* some file is loaded.

```
$LOAD_PATH << "no_existing_dir"
Encoding.default_external = Encoding::UTF_16BE
load "dummy.rb" #=> incompatible character encodings: UTF-8 and UTF-16BE
```

This issue can be actually observed by a combination of out-of-place
build and the following command:

make test-all TESTS="json ruby/m17n -n test_object_inspect_external"

http://ci.rvm.jp/logfiles/brlog.trunk-test-random.20200322-221411

ASCII-incompatible default external encoding assumes that the cwd is the
encoding, and it is attempted to beconcatenated with a non-existence
relative LOAD_PATH UTF-8 string, which causes the exception.

This changeset avoids a relative path.