### PR TITLE
test/json/json_fixtures_test.rb: Prevent an "out of range" warning

### DIFF
--- a/tests/json_fixtures_test.rb
+++ b/tests/json_fixtures_test.rb
@@ -10,6 +10,7 @@ class JSONFixturesTest < Test::Unit::TestCase
   end
 
   def test_passing
+    verbose_bak, $VERBOSE = $VERBOSE, nil
     for name, source in @passed
       begin
         assert JSON.parse(source),
@@ -19,6 +20,8 @@ class JSONFixturesTest < Test::Unit::TestCase
         raise e
       end
     end
+  ensure
+    $VERBOSE = verbose_bak
   end
 
   def test_failing


### PR DESCRIPTION
with `make test-all RUBYOPT=-w`
```
/home/mame/work/ruby/.ext/common/json/common.rb:263: warning: Float 23456789012E666 out of range
```