### PR TITLE
unify json-java gemspec with the baseline

### DIFF
--- a/java/src/json/ext/Generator.java
+++ b/java/src/json/ext/Generator.java
@@ -10,13 +10,10 @@ import org.jruby.RubyArray;
 import org.jruby.RubyBasicObject;
 import org.jruby.RubyBignum;
 import org.jruby.RubyBoolean;
-import org.jruby.RubyClass;
 import org.jruby.RubyFixnum;
 import org.jruby.RubyFloat;
 import org.jruby.RubyHash;
-import org.jruby.RubyNumeric;
 import org.jruby.RubyString;
-import org.jruby.runtime.ClassIndex;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.util.ByteList;
@@ -32,8 +29,7 @@ public final class Generator {
     static <T extends IRubyObject> RubyString
             generateJson(ThreadContext context, T object,
                          Handler<? super T> handler, IRubyObject[] args) {
-        Session session = new Session(context, args.length > 0 ? args[0]
-                                                               : null);
+        Session session = new Session(context, args.length > 0 ? args[0] : null);
         return session.infect(handler.generateNew(session, object));
     }
 
@@ -43,7 +39,7 @@ public final class Generator {
      */
     static <T extends IRubyObject> RubyString
             generateJson(ThreadContext context, T object, IRubyObject[] args) {
-        Handler<? super T> handler = getHandlerFor(context.getRuntime(), object);
+        Handler<? super T> handler = getHandlerFor(context.runtime, object);
         return generateJson(context, object, handler, args);
     }
 
@@ -55,22 +51,9 @@ public final class Generator {
             generateJson(ThreadContext context, T object,
                          GeneratorState config) {
         Session session = new Session(context, config);
-        Handler<? super T> handler = getHandlerFor(context.getRuntime(), object);
+        Handler<? super T> handler = getHandlerFor(context.runtime, object);
         return handler.generateNew(session, object);
     }
-
-    // NOTE: drop this once Ruby 1.9.3 support is gone!
-    private static final int FIXNUM = 1;
-    private static final int BIGNUM = 2;
-    private static final int ARRAY = 3;
-    private static final int STRING = 4;
-    private static final int NIL = 5;
-    private static final int TRUE = 6;
-    private static final int FALSE = 7;
-    private static final int HASH = 10;
-    private static final int FLOAT = 11;
-    // hard-coded due JRuby 1.7 compatibility
-    // https://github.com/jruby/jruby/blob/1.7.27/core/src/main/java/org/jruby/runtime/ClassIndex.java
 
     /**
      * Returns the best serialization handler for the given object.
@@ -78,10 +61,8 @@ public final class Generator {
     // Java's generics can't handle this satisfactorily, so I'll just leave
     // the best I could get and ignore the warnings
     @SuppressWarnings("unchecked")
-    private static <T extends IRubyObject>
-            Handler<? super T> getHandlerFor(Ruby runtime, T object) {
-        switch (((RubyBasicObject) object).getNativeTypeIndex()) {
-            // can not use getNativeClassIndex due 1.7 compatibility
+    private static <T extends IRubyObject> Handler<? super T> getHandlerFor(Ruby runtime, T object) {
+        switch (((RubyBasicObject) object).getNativeClassIndex()) {
             case NIL    : return (Handler) NIL_HANDLER;
             case TRUE   : return (Handler) TRUE_HANDLER;
             case FALSE  : return (Handler) FALSE_HANDLER;

--- a/json-java.gemspec
+++ b/json-java.gemspec
@@ -1,33 +1,35 @@
-#!/usr/bin/env jruby
-require "rubygems"
+# -*- encoding: utf-8 -*-
 
 spec = Gem::Specification.new do |s|
   s.name = "json"
   s.version = File.read("VERSION").chomp
-  s.summary = "JSON implementation for JRuby"
+
+  s.summary = "JSON Implementation for Ruby"
   s.description = "A JSON implementation as a JRuby extension."
+  s.licenses = ["Ruby"]
   s.author = "Daniel Luz"
   s.email = "dev+ruby@mernen.com"
-  s.homepage = "http://flori.github.com/json"
-  s.platform = 'java'
   s.licenses = ["Ruby"]
+
+  s.platform = 'java'
 
   s.files = Dir["{docs,lib,tests}/**/*"]
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 4
+  s.homepage = "http://flori.github.com/json"
+  s.metadata = {
+      'bug_tracker_uri'   => 'https://github.com/flori/json/issues',
+      'changelog_uri'     => 'https://github.com/flori/json/blob/master/CHANGES.md',
+      'documentation_uri' => 'http://flori.github.io/json/doc/index.html',
+      'homepage_uri'      => 'http://flori.github.io/json/',
+      'source_code_uri'   => 'https://github.com/flori/json',
+      'wiki_uri'          => 'https://github.com/flori/json/wiki'
+  }
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<rake>, [">= 0"])
-      s.add_development_dependency(%q<test-unit>, [">= 2.0", "< 4.0"])
-    else
-      s.add_dependency(%q<rake>, [">= 0"])
-      s.add_dependency(%q<test-unit>, [">= 2.0", "< 4.0"])
-    end
-  else
-    s.add_dependency(%q<rake>, [">= 0"])
-    s.add_dependency(%q<test-unit>, [">= 2.0", "< 4.0"])
-  end
+  s.required_ruby_version = Gem::Requirement.new(">= 2.0")
+  s.test_files = ["tests/test_helper.rb"]
+
+  s.add_development_dependency("rake", [">= 0"])
+  s.add_development_dependency("test-unit", [">= 2.0", "< 4.0"])
 end
 
 if $0 == __FILE__

--- a/json.gemspec
+++ b/json.gemspec
@@ -4,13 +4,15 @@ Gem::Specification.new do |s|
   s.name = "json"
   s.version = File.read('VERSION').chomp
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.require_paths = ["lib"]
-  s.authors = ["Florian Frank"]
+  s.summary = "JSON Implementation for Ruby"
   s.description = "This is a JSON implementation as a Ruby extension in C."
+  s.licenses = ["Ruby"]
+  s.authors = ["Florian Frank"]
   s.email = "flori@ping.de"
+
   s.extensions = ["ext/json/ext/generator/extconf.rb", "ext/json/ext/parser/extconf.rb", "ext/json/extconf.rb"]
   s.extra_rdoc_files = ["README.md"]
+  s.rdoc_options = ["--title", "JSON implemention for Ruby", "--main", "README.md"]
   s.files = [
     ".gitignore",
     ".travis.yml",
@@ -128,10 +130,8 @@ Gem::Specification.new do |s|
     'source_code_uri'   => 'https://github.com/flori/json',
     'wiki_uri'          => 'https://github.com/flori/json/wiki'
   }
-  s.licenses = ["Ruby"]
-  s.rdoc_options = ["--title", "JSON implemention for Ruby", "--main", "README.md"]
+
   s.required_ruby_version = Gem::Requirement.new(">= 2.0")
-  s.summary = "JSON Implementation for Ruby"
   s.test_files = ["tests/test_helper.rb"]
 
   s.add_development_dependency("rake", [">= 0"])


### PR DESCRIPTION
json gemspec requires Ruby 2.x while the -java platform gem does not.

doing so we could also drop some ugly code present due JRuby 1.7 (Ruby 1.9.3) compatibility.

HINT: did some (logical) re-ordering in the gemspec to "match" parts, 
think the gemspec do not need to be separate but keeping things as is, for now.