### PR TITLE
[test] properly 'skip' test on JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ rvm:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-9.1
-    - rvm: jruby-9.2
     - rvm: truffleruby
 script: "bundle exec rake"
 sudo: false

--- a/tests/json_generator_test.rb
+++ b/tests/json_generator_test.rb
@@ -49,7 +49,6 @@ EOT
   end
 
   def test_remove_const_segv
-    return if RUBY_ENGINE == 'jruby'
     stress = GC.stress
     const = JSON::SAFE_STATE_PROTOTYPE.dup
 
@@ -76,7 +75,7 @@ EOT
     silence do
       JSON.const_set :SAFE_STATE_PROTOTYPE, const
     end
-  end if JSON.const_defined?("Ext")
+  end if JSON.const_defined?("Ext") && RUBY_ENGINE != 'jruby'
 
   def test_generate
     json = generate(@hash)


### PR DESCRIPTION
an early `return` still caused [ensure to execute](https://github.com/kares/json/blob/1e31f59231d7d31dc58a1e07f228897ddd4b4d7b/tests/json_generator_test.rb#L76),
setting `JSON::SAFE_STATE_PROTOTYPE` constant to `nil` for later tests!