### PR TITLE
Nodoc for recurse_proc

### DIFF
--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -561,7 +561,7 @@ module JSON
   end
 
   # Recursively calls passed _Proc_ if the parsed data structure is an _Array_ or _Hash_
-  def recurse_proc(result, &proc)
+  def recurse_proc(result, &proc) # :nodoc:
     case result
     when Array
       result.each { |x| recurse_proc x, &proc }


### PR DESCRIPTION
Suggest :nodoc: for method recurse_proc.  It's called only (and optionally) by method load, and may not be useful to JSON users.

If we don't :nodoc: this method, it should at least have some tests, which I think are now lacking.