### PR TITLE
bundle the LICENSE file in the gem

### DIFF
--- a/json-java.gemspec
+++ b/json-java.gemspec
@@ -9,11 +9,10 @@ spec = Gem::Specification.new do |s|
   s.licenses = ["Ruby"]
   s.author = "Daniel Luz"
   s.email = "dev+ruby@mernen.com"
-  s.licenses = ["Ruby"]
 
   s.platform = 'java'
 
-  s.files = Dir["{docs,lib,tests}/**/*"]
+  s.files = Dir["{docs,lib,tests}/**/*", "LICENSE"]
 
   s.homepage = "http://flori.github.com/json"
   s.metadata = {

--- a/json.gemspec
+++ b/json.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
     ".travis.yml",
     "CHANGES.md",
     "Gemfile",
+    "LICENSE",
     "README-json-jruby.md",
     "README.md",
     "Rakefile",


### PR DESCRIPTION
From https://guides.rubygems.org/specification-reference/#license=

> (...) The full text of the license should be inside of the gem (at the top level) when you build it.

Oddly enough, `json_pure.gemspec` does include the file but not the others.

Also, `json-java.gemspec` called `licenses=` twice.