### PR TITLE
Implement a freeze: parser option

### DIFF
--- a/ext/json/ext/parser/extconf.rb
+++ b/ext/json/ext/parser/extconf.rb
@@ -3,4 +3,29 @@ require 'mkmf'
 
 have_func("rb_enc_raise", "ruby.h")
 
+# checking if String#-@ (str_uminus) dedupes... '
+begin
+  a = -(%w(t e s t).join)
+  b = -(%w(t e s t).join)
+  if a.equal?(b)
+    $CFLAGS << ' -DSTR_UMINUS_DEDUPE=1 '
+  else
+    $CFLAGS << ' -DSTR_UMINUS_DEDUPE=0 '
+  end
+rescue NoMethodError
+  $CFLAGS << ' -DSTR_UMINUS_DEDUPE=0 '
+end
+
+# checking if String#-@ (str_uminus) directly interns frozen strings... '
+begin
+  s = rand.to_s.freeze
+  if (-s).equal?(s) && (-s.dup).equal?(s)
+    $CFLAGS << ' -DSTR_UMINUS_DEDUPE_FROZEN=1 '
+  else
+    $CFLAGS << ' -DSTR_UMINUS_DEDUPE_FROZEN=0 '
+  end
+rescue NoMethodError
+  $CFLAGS << ' -DSTR_UMINUS_DEDUPE_FROZEN=0 '
+end
+
 create_makefile 'json/ext/parser'

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -97,7 +97,7 @@ static ID i_json_creatable_p, i_json_create, i_create_id, i_create_additions,
           i_chr, i_max_nesting, i_allow_nan, i_symbolize_names,
           i_object_class, i_array_class, i_decimal_class, i_key_p,
           i_deep_const_get, i_match, i_match_string, i_aset, i_aref,
-          i_leftshift, i_new, i_BigDecimal;
+          i_leftshift, i_new, i_BigDecimal, i_freeze, i_uminus;
 
 
 #line 126 "parser.rl"
@@ -869,6 +869,10 @@ case 28:
 
 #line 292 "parser.rl"
 
+    if (json->freeze) {
+        OBJ_FREEZE(*result);
+    }
+
     if (cs >= JSON_value_first_final) {
         return p;
     } else {
@@ -877,7 +881,7 @@ case 28:
 }
 
 
-#line 881 "parser.c"
+#line 885 "parser.c"
 enum {JSON_integer_start = 1};
 enum {JSON_integer_first_final = 3};
 enum {JSON_integer_error = 0};
@@ -885,7 +889,7 @@ enum {JSON_integer_error = 0};
 enum {JSON_integer_en_main = 1};
 
 
-#line 308 "parser.rl"
+#line 312 "parser.rl"
 
 
 static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *result)
@@ -893,15 +897,15 @@ static char *JSON_parse_integer(JSON_Parser *json, char *p, char *pe, VALUE *res
     int cs = EVIL;
 
 
-#line 897 "parser.c"
+#line 901 "parser.c"
 	{
 	cs = JSON_integer_start;
 	}
 
-#line 315 "parser.rl"
+#line 319 "parser.rl"
     json->memo = p;
 
-#line 905 "parser.c"
+#line 909 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -935,14 +939,14 @@ case 3:
 		goto st0;
 	goto tr4;
 tr4:
-#line 305 "parser.rl"
+#line 309 "parser.rl"
 	{ p--; {p++; cs = 4; goto _out;} }
 	goto st4;
 st4:
 	if ( ++p == pe )
 		goto _test_eof4;
 case 4:
-#line 946 "parser.c"
+#line 950 "parser.c"
 	goto st0;
 st5:
 	if ( ++p == pe )
@@ -961,7 +965,7 @@ case 5:
 	_out: {}
 	}
 
-#line 317 "parser.rl"
+#line 321 "parser.rl"
 
     if (cs >= JSON_integer_first_final) {
         long len = p - json->memo;
@@ -976,7 +980,7 @@ case 5:
 }
 
 
-#line 980 "parser.c"
+#line 984 "parser.c"
 enum {JSON_float_start = 1};
 enum {JSON_float_first_final = 8};
 enum {JSON_float_error = 0};
@@ -984,7 +988,7 @@ enum {JSON_float_error = 0};
 enum {JSON_float_en_main = 1};
 
 
-#line 342 "parser.rl"
+#line 346 "parser.rl"
 
 
 static int is_bigdecimal_class(VALUE obj)
@@ -1005,15 +1009,15 @@ static char *JSON_parse_float(JSON_Parser *json, char *p, char *pe, VALUE *resul
     int cs = EVIL;
 
 
-#line 1009 "parser.c"
+#line 1013 "parser.c"
 	{
 	cs = JSON_float_start;
 	}
 
-#line 362 "parser.rl"
+#line 366 "parser.rl"
     json->memo = p;
 
-#line 1017 "parser.c"
+#line 1021 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1071,14 +1075,14 @@ case 8:
 		goto st0;
 	goto tr9;
 tr9:
-#line 336 "parser.rl"
+#line 340 "parser.rl"
 	{ p--; {p++; cs = 9; goto _out;} }
 	goto st9;
 st9:
 	if ( ++p == pe )
 		goto _test_eof9;
 case 9:
-#line 1082 "parser.c"
+#line 1086 "parser.c"
 	goto st0;
 st5:
 	if ( ++p == pe )
@@ -1139,7 +1143,7 @@ case 7:
 	_out: {}
 	}
 
-#line 364 "parser.rl"
+#line 368 "parser.rl"
 
     if (cs >= JSON_float_first_final) {
         long len = p - json->memo;
@@ -1165,7 +1169,7 @@ case 7:
 
 
 
-#line 1169 "parser.c"
+#line 1173 "parser.c"
 enum {JSON_array_start = 1};
 enum {JSON_array_first_final = 17};
 enum {JSON_array_error = 0};
@@ -1173,7 +1177,7 @@ enum {JSON_array_error = 0};
 enum {JSON_array_en_main = 1};
 
 
-#line 417 "parser.rl"
+#line 421 "parser.rl"
 
 
 static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *result, int current_nesting)
@@ -1187,14 +1191,14 @@ static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *resul
     *result = NIL_P(array_class) ? rb_ary_new() : rb_class_new_instance(0, 0, array_class);
 
 
-#line 1191 "parser.c"
+#line 1195 "parser.c"
 	{
 	cs = JSON_array_start;
 	}
 
-#line 430 "parser.rl"
+#line 434 "parser.rl"
 
-#line 1198 "parser.c"
+#line 1202 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1233,7 +1237,7 @@ case 2:
 		goto st2;
 	goto st0;
 tr2:
-#line 394 "parser.rl"
+#line 398 "parser.rl"
 	{
         VALUE v = Qnil;
         char *np = JSON_parse_value(json, p, pe, &v, current_nesting);
@@ -1253,7 +1257,7 @@ st3:
 	if ( ++p == pe )
 		goto _test_eof3;
 case 3:
-#line 1257 "parser.c"
+#line 1261 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st3;
 		case 32: goto st3;
@@ -1353,14 +1357,14 @@ case 12:
 		goto st3;
 	goto st12;
 tr4:
-#line 409 "parser.rl"
+#line 413 "parser.rl"
 	{ p--; {p++; cs = 17; goto _out;} }
 	goto st17;
 st17:
 	if ( ++p == pe )
 		goto _test_eof17;
 case 17:
-#line 1364 "parser.c"
+#line 1368 "parser.c"
 	goto st0;
 st13:
 	if ( ++p == pe )
@@ -1416,7 +1420,7 @@ case 16:
 	_out: {}
 	}
 
-#line 431 "parser.rl"
+#line 435 "parser.rl"
 
     if(cs >= JSON_array_first_final) {
         return p + 1;
@@ -1505,7 +1509,7 @@ static VALUE json_string_unescape(VALUE result, char *string, char *stringEnd)
 }
 
 
-#line 1509 "parser.c"
+#line 1513 "parser.c"
 enum {JSON_string_start = 1};
 enum {JSON_string_first_final = 8};
 enum {JSON_string_error = 0};
@@ -1513,7 +1517,7 @@ enum {JSON_string_error = 0};
 enum {JSON_string_en_main = 1};
 
 
-#line 538 "parser.rl"
+#line 542 "parser.rl"
 
 
 static int
@@ -1535,15 +1539,15 @@ static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *resu
 
     *result = rb_str_buf_new(0);
 
-#line 1539 "parser.c"
+#line 1543 "parser.c"
 	{
 	cs = JSON_string_start;
 	}
 
-#line 559 "parser.rl"
+#line 563 "parser.rl"
     json->memo = p;
 
-#line 1547 "parser.c"
+#line 1551 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1568,7 +1572,7 @@ case 2:
 		goto st0;
 	goto st2;
 tr2:
-#line 524 "parser.rl"
+#line 528 "parser.rl"
 	{
         *result = json_string_unescape(*result, json->memo + 1, p);
         if (NIL_P(*result)) {
@@ -1579,14 +1583,14 @@ tr2:
             {p = (( p + 1))-1;}
         }
     }
-#line 535 "parser.rl"
+#line 539 "parser.rl"
 	{ p--; {p++; cs = 8; goto _out;} }
 	goto st8;
 st8:
 	if ( ++p == pe )
 		goto _test_eof8;
 case 8:
-#line 1590 "parser.c"
+#line 1594 "parser.c"
 	goto st0;
 st3:
 	if ( ++p == pe )
@@ -1662,7 +1666,7 @@ case 7:
 	_out: {}
 	}
 
-#line 561 "parser.rl"
+#line 565 "parser.rl"
 
     if (json->create_additions && RTEST(match_string = json->match_string)) {
           VALUE klass;
@@ -1678,7 +1682,22 @@ case 7:
     if (json->symbolize_names && json->parsing_name) {
       *result = rb_str_intern(*result);
     } else if (RB_TYPE_P(*result, T_STRING)) {
+# if STR_UMINUS_DEDUPE_FROZEN
+      if (json->freeze) {
+        // Starting from MRI 2.8 it is preferable to freeze the string
+        // before deduplication so that it can be interned directly
+        // otherwise it would be duplicated first which is wasteful.
+        *result = rb_funcall(rb_str_freeze(*result), i_uminus, 0);
+      }
+# elif STR_UMINUS_DEDUPE
+      if (json->freeze) {
+        // MRI 2.5 and older do not deduplicate strings that are already
+        // frozen.
+        *result = rb_funcall(*result, i_uminus, 0);
+      }
+# else
       rb_str_resize(*result, RSTRING_LEN(*result));
+# endif
     }
     if (cs >= JSON_string_first_final) {
         return p + 1;
@@ -1786,6 +1805,12 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
             } else {
                 json->symbolize_names = 0;
             }
+            tmp = ID2SYM(i_freeze);
+            if (option_given_p(opts, tmp)) {
+                json->freeze = RTEST(rb_hash_aref(opts, tmp)) ? 1 : 0;
+            } else {
+                json->freeze = 0;
+            }
             tmp = ID2SYM(i_create_additions);
             if (option_given_p(opts, tmp)) {
                 json->create_additions = RTEST(rb_hash_aref(opts, tmp));
@@ -1849,7 +1874,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
 }
 
 
-#line 1853 "parser.c"
+#line 1878 "parser.c"
 enum {JSON_start = 1};
 enum {JSON_first_final = 10};
 enum {JSON_error = 0};
@@ -1857,7 +1882,7 @@ enum {JSON_error = 0};
 enum {JSON_en_main = 1};
 
 
-#line 761 "parser.rl"
+#line 786 "parser.rl"
 
 
 /*
@@ -1874,16 +1899,16 @@ static VALUE cParser_parse(VALUE self)
   GET_PARSER;
 
 
-#line 1878 "parser.c"
+#line 1903 "parser.c"
 	{
 	cs = JSON_start;
 	}
 
-#line 777 "parser.rl"
+#line 802 "parser.rl"
   p = json->source;
   pe = p + json->len;
 
-#line 1887 "parser.c"
+#line 1912 "parser.c"
 	{
 	if ( p == pe )
 		goto _test_eof;
@@ -1917,7 +1942,7 @@ st0:
 cs = 0;
 	goto _out;
 tr2:
-#line 753 "parser.rl"
+#line 778 "parser.rl"
 	{
         char *np = JSON_parse_value(json, p, pe, &result, 0);
         if (np == NULL) { p--; {p++; cs = 10; goto _out;} } else {p = (( np))-1;}
@@ -1927,7 +1952,7 @@ st10:
 	if ( ++p == pe )
 		goto _test_eof10;
 case 10:
-#line 1931 "parser.c"
+#line 1956 "parser.c"
 	switch( (*p) ) {
 		case 13: goto st10;
 		case 32: goto st10;
@@ -2016,7 +2041,7 @@ case 9:
 	_out: {}
 	}
 
-#line 780 "parser.rl"
+#line 805 "parser.rl"
 
   if (cs >= JSON_first_final && p == pe) {
     return result;
@@ -2126,6 +2151,8 @@ void Init_parser(void)
     i_leftshift = rb_intern("<<");
     i_new = rb_intern("new");
     i_BigDecimal = rb_intern("BigDecimal");
+    i_freeze = rb_intern("freeze");
+    i_uminus = rb_intern("-@");
 }
 
 /*

--- a/ext/json/ext/parser/parser.h
+++ b/ext/json/ext/parser/parser.h
@@ -37,6 +37,7 @@ typedef struct JSON_ParserStruct {
     int allow_nan;
     int parsing_name;
     int symbolize_names;
+    int freeze;
     VALUE object_class;
     VALUE array_class;
     VALUE decimal_class;

--- a/ext/json/extconf.rb
+++ b/ext/json/extconf.rb
@@ -1,2 +1,3 @@
 require 'mkmf'
+
 create_makefile('json')

--- a/java/src/json/ext/Parser.java
+++ b/java/src/json/ext/Parser.java
@@ -52,6 +52,7 @@ public class Parser extends RubyObject {
     private int maxNesting;
     private boolean allowNaN;
     private boolean symbolizeNames;
+    private boolean freeze;
     private RubyClass objectClass;
     private RubyClass arrayClass;
     private RubyClass decimalClass;
@@ -160,6 +161,7 @@ public class Parser extends RubyObject {
         this.maxNesting      = opts.getInt("max_nesting", DEFAULT_MAX_NESTING);
         this.allowNaN        = opts.getBool("allow_nan", false);
         this.symbolizeNames  = opts.getBool("symbolize_names", false);
+        this.freeze          = opts.getBool("freeze", false);
         this.createId        = opts.getString("create_id", getCreateId(context));
         this.createAdditions = opts.getBool("create_additions", false);
         this.objectClass     = opts.getClass("object_class", runtime.getHash());
@@ -313,11 +315,11 @@ public class Parser extends RubyObject {
         }
 
         
-// line 339 "Parser.rl"
+// line 341 "Parser.rl"
 
 
         
-// line 321 "Parser.java"
+// line 323 "Parser.java"
 private static byte[] init__JSON_value_actions_0()
 {
 	return new byte [] {
@@ -431,7 +433,7 @@ static final int JSON_value_error = 0;
 static final int JSON_value_en_main = 1;
 
 
-// line 445 "Parser.rl"
+// line 447 "Parser.rl"
 
 
         void parseValue(ParserResult res, int p, int pe) {
@@ -439,14 +441,14 @@ static final int JSON_value_en_main = 1;
             IRubyObject result = null;
 
             
-// line 443 "Parser.java"
+// line 445 "Parser.java"
 	{
 	cs = JSON_value_start;
 	}
 
-// line 452 "Parser.rl"
+// line 454 "Parser.rl"
             
-// line 450 "Parser.java"
+// line 452 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -472,13 +474,13 @@ case 1:
 	while ( _nacts-- > 0 ) {
 		switch ( _JSON_value_actions[_acts++] ) {
 	case 9:
-// line 430 "Parser.rl"
+// line 432 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 482 "Parser.java"
+// line 484 "Parser.java"
 		}
 	}
 
@@ -541,25 +543,25 @@ case 1:
 			switch ( _JSON_value_actions[_acts++] )
 			{
 	case 0:
-// line 347 "Parser.rl"
+// line 349 "Parser.rl"
 	{
                 result = getRuntime().getNil();
             }
 	break;
 	case 1:
-// line 350 "Parser.rl"
+// line 352 "Parser.rl"
 	{
                 result = getRuntime().getFalse();
             }
 	break;
 	case 2:
-// line 353 "Parser.rl"
+// line 355 "Parser.rl"
 	{
                 result = getRuntime().getTrue();
             }
 	break;
 	case 3:
-// line 356 "Parser.rl"
+// line 358 "Parser.rl"
 	{
                 if (parser.allowNaN) {
                     result = getConstant(CONST_NAN);
@@ -569,7 +571,7 @@ case 1:
             }
 	break;
 	case 4:
-// line 363 "Parser.rl"
+// line 365 "Parser.rl"
 	{
                 if (parser.allowNaN) {
                     result = getConstant(CONST_INFINITY);
@@ -579,7 +581,7 @@ case 1:
             }
 	break;
 	case 5:
-// line 370 "Parser.rl"
+// line 372 "Parser.rl"
 	{
                 if (pe > p + 8 &&
                     absSubSequence(p, p + 9).equals(JSON_MINUS_INFINITY)) {
@@ -608,7 +610,7 @@ case 1:
             }
 	break;
 	case 6:
-// line 396 "Parser.rl"
+// line 398 "Parser.rl"
 	{
                 parseString(res, p, pe);
                 if (res.result == null) {
@@ -621,7 +623,7 @@ case 1:
             }
 	break;
 	case 7:
-// line 406 "Parser.rl"
+// line 408 "Parser.rl"
 	{
                 currentNesting++;
                 parseArray(res, p, pe);
@@ -636,7 +638,7 @@ case 1:
             }
 	break;
 	case 8:
-// line 418 "Parser.rl"
+// line 420 "Parser.rl"
 	{
                 currentNesting++;
                 parseObject(res, p, pe);
@@ -650,7 +652,7 @@ case 1:
                 }
             }
 	break;
-// line 654 "Parser.java"
+// line 656 "Parser.java"
 			}
 		}
 	}
@@ -670,9 +672,12 @@ case 5:
 	break; }
 	}
 
-// line 453 "Parser.rl"
+// line 455 "Parser.rl"
 
             if (cs >= JSON_value_first_final && result != null) {
+                if (parser.freeze) {
+                  result.setFrozen(true);
+                }
                 res.update(result, p);
             } else {
                 res.update(null, p);
@@ -680,7 +685,7 @@ case 5:
         }
 
         
-// line 684 "Parser.java"
+// line 689 "Parser.java"
 private static byte[] init__JSON_integer_actions_0()
 {
 	return new byte [] {
@@ -779,7 +784,7 @@ static final int JSON_integer_error = 0;
 static final int JSON_integer_en_main = 1;
 
 
-// line 472 "Parser.rl"
+// line 477 "Parser.rl"
 
 
         void parseInteger(ParserResult res, int p, int pe) {
@@ -797,15 +802,15 @@ static final int JSON_integer_en_main = 1;
             int cs = EVIL;
 
             
-// line 801 "Parser.java"
+// line 806 "Parser.java"
 	{
 	cs = JSON_integer_start;
 	}
 
-// line 489 "Parser.rl"
+// line 494 "Parser.rl"
             int memo = p;
             
-// line 809 "Parser.java"
+// line 814 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -886,13 +891,13 @@ case 1:
 			switch ( _JSON_integer_actions[_acts++] )
 			{
 	case 0:
-// line 466 "Parser.rl"
+// line 471 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 896 "Parser.java"
+// line 901 "Parser.java"
 			}
 		}
 	}
@@ -912,7 +917,7 @@ case 5:
 	break; }
 	}
 
-// line 491 "Parser.rl"
+// line 496 "Parser.rl"
 
             if (cs < JSON_integer_first_final) {
                 return -1;
@@ -934,7 +939,7 @@ case 5:
         }
 
         
-// line 938 "Parser.java"
+// line 943 "Parser.java"
 private static byte[] init__JSON_float_actions_0()
 {
 	return new byte [] {
@@ -1036,7 +1041,7 @@ static final int JSON_float_error = 0;
 static final int JSON_float_en_main = 1;
 
 
-// line 526 "Parser.rl"
+// line 531 "Parser.rl"
 
 
         void parseFloat(ParserResult res, int p, int pe) {
@@ -1056,15 +1061,15 @@ static final int JSON_float_en_main = 1;
             int cs = EVIL;
 
             
-// line 1060 "Parser.java"
+// line 1065 "Parser.java"
 	{
 	cs = JSON_float_start;
 	}
 
-// line 545 "Parser.rl"
+// line 550 "Parser.rl"
             int memo = p;
             
-// line 1068 "Parser.java"
+// line 1073 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1145,13 +1150,13 @@ case 1:
 			switch ( _JSON_float_actions[_acts++] )
 			{
 	case 0:
-// line 517 "Parser.rl"
+// line 522 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1155 "Parser.java"
+// line 1160 "Parser.java"
 			}
 		}
 	}
@@ -1171,7 +1176,7 @@ case 5:
 	break; }
 	}
 
-// line 547 "Parser.rl"
+// line 552 "Parser.rl"
 
             if (cs < JSON_float_first_final) {
                 return -1;
@@ -1194,7 +1199,7 @@ case 5:
         }
 
         
-// line 1198 "Parser.java"
+// line 1203 "Parser.java"
 private static byte[] init__JSON_string_actions_0()
 {
 	return new byte [] {
@@ -1296,7 +1301,7 @@ static final int JSON_string_error = 0;
 static final int JSON_string_en_main = 1;
 
 
-// line 599 "Parser.rl"
+// line 604 "Parser.rl"
 
 
         void parseString(ParserResult res, int p, int pe) {
@@ -1304,15 +1309,15 @@ static final int JSON_string_en_main = 1;
             IRubyObject result = null;
 
             
-// line 1308 "Parser.java"
+// line 1313 "Parser.java"
 	{
 	cs = JSON_string_start;
 	}
 
-// line 606 "Parser.rl"
+// line 611 "Parser.rl"
             int memo = p;
             
-// line 1316 "Parser.java"
+// line 1321 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1393,7 +1398,7 @@ case 1:
 			switch ( _JSON_string_actions[_acts++] )
 			{
 	case 0:
-// line 574 "Parser.rl"
+// line 579 "Parser.rl"
 	{
                 int offset = byteList.begin();
                 ByteList decoded = decoder.decode(byteList, memo + 1 - offset,
@@ -1408,13 +1413,13 @@ case 1:
             }
 	break;
 	case 1:
-// line 587 "Parser.rl"
+// line 592 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1418 "Parser.java"
+// line 1423 "Parser.java"
 			}
 		}
 	}
@@ -1434,7 +1439,7 @@ case 5:
 	break; }
 	}
 
-// line 608 "Parser.rl"
+// line 613 "Parser.rl"
 
             if (parser.createAdditions) {
                 RubyHash matchString = parser.match_string;
@@ -1463,16 +1468,23 @@ case 5:
 
             if (cs >= JSON_string_first_final && result != null) {
                 if (result instanceof RubyString) {
-                  ((RubyString)result).force_encoding(context, info.utf8.get());
+                  RubyString string = (RubyString)result;
+                  string.force_encoding(context, info.utf8.get());
+                  if (parser.freeze) {
+                     string.setFrozen(true);
+                     string = getRuntime().freezeAndDedupString(string);
+                  }
+                  res.update(string, p + 1);
+                } else {
+                  res.update(result, p + 1);
                 }
-                res.update(result, p + 1);
             } else {
                 res.update(null, p + 1);
             }
         }
 
         
-// line 1476 "Parser.java"
+// line 1488 "Parser.java"
 private static byte[] init__JSON_array_actions_0()
 {
 	return new byte [] {
@@ -1585,7 +1597,7 @@ static final int JSON_array_error = 0;
 static final int JSON_array_en_main = 1;
 
 
-// line 681 "Parser.rl"
+// line 693 "Parser.rl"
 
 
         void parseArray(ParserResult res, int p, int pe) {
@@ -1605,14 +1617,14 @@ static final int JSON_array_en_main = 1;
             }
 
             
-// line 1609 "Parser.java"
+// line 1621 "Parser.java"
 	{
 	cs = JSON_array_start;
 	}
 
-// line 700 "Parser.rl"
+// line 712 "Parser.rl"
             
-// line 1616 "Parser.java"
+// line 1628 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1693,7 +1705,7 @@ case 1:
 			switch ( _JSON_array_actions[_acts++] )
 			{
 	case 0:
-// line 650 "Parser.rl"
+// line 662 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -1710,13 +1722,13 @@ case 1:
             }
 	break;
 	case 1:
-// line 665 "Parser.rl"
+// line 677 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 1720 "Parser.java"
+// line 1732 "Parser.java"
 			}
 		}
 	}
@@ -1736,7 +1748,7 @@ case 5:
 	break; }
 	}
 
-// line 701 "Parser.rl"
+// line 713 "Parser.rl"
 
             if (cs >= JSON_array_first_final) {
                 res.update(result, p + 1);
@@ -1746,7 +1758,7 @@ case 5:
         }
 
         
-// line 1750 "Parser.java"
+// line 1762 "Parser.java"
 private static byte[] init__JSON_object_actions_0()
 {
 	return new byte [] {
@@ -1869,7 +1881,7 @@ static final int JSON_object_error = 0;
 static final int JSON_object_en_main = 1;
 
 
-// line 760 "Parser.rl"
+// line 772 "Parser.rl"
 
 
         void parseObject(ParserResult res, int p, int pe) {
@@ -1894,14 +1906,14 @@ static final int JSON_object_en_main = 1;
             }
 
             
-// line 1898 "Parser.java"
+// line 1910 "Parser.java"
 	{
 	cs = JSON_object_start;
 	}
 
-// line 784 "Parser.rl"
+// line 796 "Parser.rl"
             
-// line 1905 "Parser.java"
+// line 1917 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -1982,7 +1994,7 @@ case 1:
 			switch ( _JSON_object_actions[_acts++] )
 			{
 	case 0:
-// line 715 "Parser.rl"
+// line 727 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -1999,7 +2011,7 @@ case 1:
             }
 	break;
 	case 1:
-// line 730 "Parser.rl"
+// line 742 "Parser.rl"
 	{
                 parseString(res, p, pe);
                 if (res.result == null) {
@@ -2019,13 +2031,13 @@ case 1:
             }
 	break;
 	case 2:
-// line 748 "Parser.rl"
+// line 760 "Parser.rl"
 	{
                 p--;
                 { p += 1; _goto_targ = 5; if (true)  continue _goto;}
             }
 	break;
-// line 2029 "Parser.java"
+// line 2041 "Parser.java"
 			}
 		}
 	}
@@ -2045,7 +2057,7 @@ case 5:
 	break; }
 	}
 
-// line 785 "Parser.rl"
+// line 797 "Parser.rl"
 
             if (cs < JSON_object_first_final) {
                 res.update(null, p + 1);
@@ -2078,7 +2090,7 @@ case 5:
         }
 
         
-// line 2082 "Parser.java"
+// line 2094 "Parser.java"
 private static byte[] init__JSON_actions_0()
 {
 	return new byte [] {
@@ -2181,7 +2193,7 @@ static final int JSON_error = 0;
 static final int JSON_en_main = 1;
 
 
-// line 836 "Parser.rl"
+// line 848 "Parser.rl"
 
 
         public IRubyObject parseImplemetation() {
@@ -2191,16 +2203,16 @@ static final int JSON_en_main = 1;
             ParserResult res = new ParserResult();
 
             
-// line 2195 "Parser.java"
+// line 2207 "Parser.java"
 	{
 	cs = JSON_start;
 	}
 
-// line 845 "Parser.rl"
+// line 857 "Parser.rl"
             p = byteList.begin();
             pe = p + byteList.length();
             
-// line 2204 "Parser.java"
+// line 2216 "Parser.java"
 	{
 	int _klen;
 	int _trans = 0;
@@ -2281,7 +2293,7 @@ case 1:
 			switch ( _JSON_actions[_acts++] )
 			{
 	case 0:
-// line 822 "Parser.rl"
+// line 834 "Parser.rl"
 	{
                 parseValue(res, p, pe);
                 if (res.result == null) {
@@ -2293,7 +2305,7 @@ case 1:
                 }
             }
 	break;
-// line 2297 "Parser.java"
+// line 2309 "Parser.java"
 			}
 		}
 	}
@@ -2313,7 +2325,7 @@ case 5:
 	break; }
 	}
 
-// line 848 "Parser.rl"
+// line 860 "Parser.rl"
 
             if (cs >= JSON_first_final && p == pe) {
                 return result;

--- a/tests/json_parser_test.rb
+++ b/tests/json_parser_test.rb
@@ -218,6 +218,17 @@ class JSONParserTest < Test::Unit::TestCase
     end
   end
 
+  def test_freeze
+    assert_predicate parse('{}', :freeze => true), :frozen?
+    assert_predicate parse('[]', :freeze => true), :frozen?
+    assert_predicate parse('"foo"', :freeze => true), :frozen?
+    
+    if string_deduplication_available?
+      assert_same -'foo', parse('"foo"', :freeze => true)
+      assert_same -'foo', parse('{"foo": 1}', :freeze => true).keys.first
+    end
+  end
+
   def test_parse_comments
     json = <<EOT
 {
@@ -467,6 +478,16 @@ EOT
   end
 
   private
+
+  def string_deduplication_available?
+    r1 = rand.to_s
+    r2 = r1.dup
+    begin
+      (-r1).equal?(-r2)
+    rescue NoMethodError
+      false # No String#-@
+    end
+  end
 
   def assert_equal_float(expected, actual, delta = 1e-2)
     Array === expected and expected = expected.first


### PR DESCRIPTION
If set to true all parsed objects will be immediately frozen, and strings will be deduplicated if the Ruby implementation allows it.

This option is useful if you plan to keep the parsed objects around, and want to reduce their memory footprint, and you know they contain duplicated string. It's common in says I18n data, or some database like configuration files (e.g. tax rates etc). 

A similar option was added to YAML/Pysch: https://github.com/ruby/psych/pull/414

MessagePack is also about to have it: https://github.com/msgpack/msgpack-ruby/pull/194 (at least the principle was accepted).

Right now this option incur a small overhead because it has to call `String#-@` through `rb_funcall`, but hopefully Ruby 3.0 should soon expose `rb_fstring_new(const char *ptr, long len) (likely under another name)` which should allow to reduce allocations by directly looking up existing strings without allocating a new one. 

NB: I presume that a java implementation is needed, I'm not too well versed into Java by I can try my hand at it. However I'd rather have your feedback on the MRI and "pure" implementations first.