### PR TITLE
Fix an issue with generate_pretty and empty objects in the Ruby and Java implementations

### DIFF
--- a/java/src/json/ext/Generator.java
+++ b/java/src/json/ext/Generator.java
@@ -334,13 +334,13 @@ public final class Generator {
 
                 buffer.append((byte)'{');
                 buffer.append(objectNl);
-                object.visitAll(new RubyHash.Visitor() {
-                    private boolean firstPair = true;
 
+                final boolean[] firstPair = new boolean[]{true};
+                object.visitAll(new RubyHash.Visitor() {
                     @Override
                     public void visit(IRubyObject key, IRubyObject value) {
-                        if (firstPair) {
-                            firstPair = false;
+                        if (firstPair[0]) {
+                            firstPair[0] = false;
                         } else {
                             buffer.append((byte)',');
                             buffer.append(objectNl);
@@ -360,7 +360,7 @@ public final class Generator {
                     }
                 });
                 state.decreaseDepth();
-                if (objectNl.length() != 0) {
+                if (!firstPair[0] && objectNl.length() != 0) {
                     buffer.append(objectNl);
                     buffer.append(Utils.repeat(state.getIndent(), state.getDepth()));
                 }

--- a/lib/json/pure/generator.rb
+++ b/lib/json/pure/generator.rb
@@ -332,8 +332,10 @@ module JSON
               first = false
             }
             depth = state.depth -= 1
-            result << state.object_nl
-            result << state.indent * depth if indent
+            unless first
+              result << state.object_nl
+              result << state.indent * depth if indent
+            end
             result << '}'
             result
           end

--- a/tests/json_generator_test.rb
+++ b/tests/json_generator_test.rb
@@ -92,6 +92,11 @@ EOT
   end
 
   def test_generate_pretty
+    json = pretty_generate({})
+    assert_equal(<<'EOT'.chomp, json)
+{
+}
+EOT
     json = pretty_generate(@hash)
     # hashes aren't (insertion) ordered on every ruby implementation
     # assert_equal(@json3, json)


### PR DESCRIPTION
Fixed #441.