### PR TITLE
Use rb_str_buf_new() to improve JSON.parse() performance with short string

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -1440,7 +1440,7 @@ static VALUE json_string_unescape(VALUE result, char *string, char *stringEnd)
         if (*pe == '\\') {
             unescape = (char *) "?";
             unescape_len = 1;
-            if (pe > p) rb_str_buf_cat(result, p, pe - p);
+            if (pe > p) rb_str_cat(result, p, pe - p);
             switch (*++pe) {
                 case 'n':
                     unescape = (char *) "\n";
@@ -1498,13 +1498,13 @@ static VALUE json_string_unescape(VALUE result, char *string, char *stringEnd)
                     p = pe;
                     continue;
             }
-            rb_str_buf_cat(result, unescape, unescape_len);
+            rb_str_cat(result, unescape, unescape_len);
             p = ++pe;
         } else {
             pe++;
         }
     }
-    rb_str_buf_cat(result, p, pe - p);
+    rb_str_cat(result, p, pe - p);
     return result;
 }
 
@@ -1537,7 +1537,7 @@ static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *resu
     int cs = EVIL;
     VALUE match_string;
 
-    *result = rb_str_buf_new(0);
+    *result = rb_str_new(0, 0);
 
 #line 1543 "parser.c"
 	{

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -451,7 +451,7 @@ static VALUE json_string_unescape(VALUE result, char *string, char *stringEnd)
         if (*pe == '\\') {
             unescape = (char *) "?";
             unescape_len = 1;
-            if (pe > p) rb_str_buf_cat(result, p, pe - p);
+            if (pe > p) rb_str_cat(result, p, pe - p);
             switch (*++pe) {
                 case 'n':
                     unescape = (char *) "\n";
@@ -509,13 +509,13 @@ static VALUE json_string_unescape(VALUE result, char *string, char *stringEnd)
                     p = pe;
                     continue;
             }
-            rb_str_buf_cat(result, unescape, unescape_len);
+            rb_str_cat(result, unescape, unescape_len);
             p = ++pe;
         } else {
             pe++;
         }
     }
-    rb_str_buf_cat(result, p, pe - p);
+    rb_str_cat(result, p, pe - p);
     return result;
 }
 
@@ -558,7 +558,7 @@ static char *JSON_parse_string(JSON_Parser *json, char *p, char *pe, VALUE *resu
     int cs = EVIL;
     VALUE match_string;
 
-    *result = rb_str_buf_new(0);
+    *result = rb_str_new(0, 0);
     %% write init;
     json->memo = p;
     %% write exec;


### PR DESCRIPTION
`rb_str_buf_new` always performs allocation twice (at `str_alloc` and `ALLOC_N`).
And the method does not allow embedded string even if the string is short enough.

```
VALUE
rb_str_buf_new(long capa)
{
    VALUE str = str_alloc(rb_cString);

    if (capa < STR_BUF_MIN_SIZE) {
        capa = STR_BUF_MIN_SIZE;
    }
    FL_SET(str, STR_NOEMBED);
    RSTRING(str)->as.heap.aux.capa = capa;
    RSTRING(str)->as.heap.ptr = ALLOC_N(char, (size_t)capa + 1);
    RSTRING(str)->as.heap.ptr[0] = '\0';

    return str;
}
```

Therefore, this PR uses `rb_str_new` instead to reduce the allocation with a short string.
This PR will improve the performance by about 16%.

### Environment
- MacBook Pro (16-inch, 2019)
- macOS 10.15.5
- Intel Core i9 2.4 GHz
- Ruby 2.7.2

### Before
```
Warming up --------------------------------------
   short_string_json    10.660k i/100ms
    long_string_json    10.058k i/100ms
Calculating -------------------------------------
   short_string_json    106.992k (± 1.4%) i/s -    543.660k in   5.082355s
    long_string_json    102.273k (± 1.0%) i/s -    512.958k in   5.016081s
```

### After
```
Warming up --------------------------------------
   short_string_json    12.413k i/100ms
    long_string_json    10.457k i/100ms
Calculating -------------------------------------
   short_string_json    124.316k (± 0.8%) i/s -    633.063k in   5.092705s
    long_string_json    105.665k (± 0.9%) i/s -    533.307k in   5.047540s
```

### Test code
```ruby
require 'benchmark/ips'
require 'json'

short_string_json = {
  "a" => "b" * 23,
  "a" * 23 => "b"
}.to_json.freeze

long_string_json = {
  "a" => "b" * 50,
  "a" * 50 => "b"
}.to_json.freeze

Benchmark.ips do |x|
  x.report("short_string_json") { JSON.parse(short_string_json) }
  x.report("long_string_json") { JSON.parse(long_string_json) }
end
```