### PR TITLE
Remove unnecessary initialization of create_id in JSON.parse()

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -1860,7 +1860,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
         json->max_nesting = 100;
         json->allow_nan = 0;
         json->create_additions = 0;
-        json->create_id = rb_funcall(mJSON, i_create_id, 0);
+        json->create_id = Qnil;
         json->object_class = Qnil;
         json->array_class = Qnil;
         json->decimal_class = Qnil;

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -755,7 +755,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
         json->max_nesting = 100;
         json->allow_nan = 0;
         json->create_additions = 0;
-        json->create_id = rb_funcall(mJSON, i_create_id, 0);
+        json->create_id = Qnil;
         json->object_class = Qnil;
         json->array_class = Qnil;
         json->decimal_class = Qnil;


### PR DESCRIPTION
The `create_id` has no effect if `create_additions` is false.

> * * *create_additions*: If set to false, the Parser doesn't create
> *   additions even if a matching class and create_id was found. This option
> *   defaults to false.

https://github.com/flori/json/blob/8f7ddba3cd343c2bada3c31c9660c63f0c6df114/ext/json/ext/parser/parser.c#L1758-L1760

So, this PR will remove initialization of `create_id` when `create_additions` is false.
This PR will improve JSON.parse() performance about 6%.

### Environment
- MacBook Pro (16-inch, 2019)
- macOS 11.1
- Intel Core i9 2.4 GHz
- Ruby 2.7.2

### Before
```
Warming up --------------------------------------
   short_string_json    10.920k i/100ms
    long_string_json    10.326k i/100ms
Calculating -------------------------------------
   short_string_json    107.833k (± 1.1%) i/s -    546.000k in   5.064049s
    long_string_json    103.035k (± 0.9%) i/s -    516.300k in   5.011344s
```

### After
```
Warming up --------------------------------------
   short_string_json    11.654k i/100ms
    long_string_json    11.021k i/100ms
Calculating -------------------------------------
   short_string_json    115.564k (± 0.7%) i/s -    582.700k in   5.042516s
    long_string_json    109.216k (± 0.6%) i/s -    551.050k in   5.045726s
```

### Test code
```ruby
require 'benchmark/ips'
require 'json'

short_string_json = {
  "a" => "b" * 23,
  "a" * 23 => "b"
}.to_json.freeze

long_string_json = {
  "a" => "b" * 50,
  "a" * 50 => "b"
}.to_json.freeze

Benchmark.ips do |x|
  x.report("short_string_json") { JSON.parse(short_string_json) }
  x.report("long_string_json") { JSON.parse(long_string_json) }
end
```