### PR TITLE
Fix incorrect `#` position in API doc

### DIFF
--- a/lib/json.rb
+++ b/lib/json.rb
@@ -493,7 +493,7 @@ require 'json/common'
 #   json = JSON.generate(ruby0) # {"json_class":"Customer","v":["Dave","123 Main"]}
 #   ruby1 = JSON.parse(json, create_additions: true) # #<struct Customer name="Dave", address="123 Main">
 #   ruby1.class # Customer
-  #
+#
 # \Symbol:
 #   require 'json/add/symbol'
 #   ruby0 = :foo # foo


### PR DESCRIPTION
This change fixes an incorrect `#` position in the API documentation of the `JSON` module.

NOTE:
I noticed the incorrect position while I looked into <https://github.com/lsegal/yard/issues/1363>.
Even if this change is merged, <https://www.rubydoc.info/gems/json/JSON> will not show the correct overview.
