### PR TITLE
Stop including the parser source __LINE__ in exceptions

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -997,10 +997,10 @@ static void generate_json_float(FBuffer *buffer, VALUE Vstate, JSON_Generator_St
     if (!allow_nan) {
         if (isinf(value)) {
             fbuffer_free(buffer);
-            rb_raise(eGeneratorError, "%u: %"PRIsVALUE" not allowed in JSON", __LINE__, RB_OBJ_STRING(tmp));
+            rb_raise(eGeneratorError, "%"PRIsVALUE" not allowed in JSON", RB_OBJ_STRING(tmp));
         } else if (isnan(value)) {
             fbuffer_free(buffer);
-            rb_raise(eGeneratorError, "%u: %"PRIsVALUE" not allowed in JSON", __LINE__, RB_OBJ_STRING(tmp));
+            rb_raise(eGeneratorError, "%"PRIsVALUE" not allowed in JSON", RB_OBJ_STRING(tmp));
         }
     }
     fbuffer_append_str(buffer, tmp);

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -948,7 +948,7 @@ static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *resul
 
 					{p = p - 1; } {p+= 1; cs = 29; goto _out;}
 				} else {
-					rb_enc_raise(EXC_ENCODING eParserError, "%u: unexpected token at '%s'", __LINE__, p);
+					rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p);
 				}
 			}
 			np = JSON_parse_float(json, p, pe, result);
@@ -990,7 +990,7 @@ static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *resul
 			if (json->allow_nan) {
 				*result = CInfinity;
 			} else {
-				rb_enc_raise(EXC_ENCODING eParserError, "%u: unexpected token at '%s'", __LINE__, p - 8);
+				rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p - 8);
 			}
 		}
 
@@ -1002,7 +1002,7 @@ static char *JSON_parse_value(JSON_Parser *json, char *p, char *pe, VALUE *resul
 			if (json->allow_nan) {
 				*result = CNaN;
 			} else {
-				rb_enc_raise(EXC_ENCODING eParserError, "%u: unexpected token at '%s'", __LINE__, p - 2);
+				rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p - 2);
 			}
 		}
 
@@ -2348,7 +2348,7 @@ static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *resul
 	if(cs >= JSON_array_first_final) {
 		return p + 1;
 	} else {
-		rb_enc_raise(EXC_ENCODING eParserError, "%u: unexpected token at '%s'", __LINE__, p);
+		rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p);
 		return NULL;
 	}
 }
@@ -2405,7 +2405,7 @@ static VALUE json_string_unescape(char *string, char *stringEnd, int intern, int
 					}
 					rb_enc_raise(
 					EXC_ENCODING eParserError,
-					"%u: incomplete unicode character escape sequence at '%s'", __LINE__, p
+					"incomplete unicode character escape sequence at '%s'", p
 					);
 				} else {
 					UTF32 ch = unescape_unicode((unsigned char *) ++pe);
@@ -2418,7 +2418,7 @@ static VALUE json_string_unescape(char *string, char *stringEnd, int intern, int
 							}
 							rb_enc_raise(
 							EXC_ENCODING eParserError,
-							"%u: incomplete surrogate pair at '%s'", __LINE__, p
+							"incomplete surrogate pair at '%s'", p
 							);
 						}
 						if (pe[0] == '\\' && pe[1] == 'u') {
@@ -3217,7 +3217,7 @@ static VALUE cParser_parse(VALUE self)
 	if (cs >= JSON_first_final && p == pe) {
 		return result;
 	} else {
-		rb_enc_raise(EXC_ENCODING eParserError, "%u: unexpected token at '%s'", __LINE__, p);
+		rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p);
 		return Qnil;
 	}
 }

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -222,14 +222,14 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
         if (json->allow_nan) {
             *result = CNaN;
         } else {
-            rb_enc_raise(EXC_ENCODING eParserError, "%u: unexpected token at '%s'", __LINE__, p - 2);
+            rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p - 2);
         }
     }
     action parse_infinity {
         if (json->allow_nan) {
             *result = CInfinity;
         } else {
-            rb_enc_raise(EXC_ENCODING eParserError, "%u: unexpected token at '%s'", __LINE__, p - 8);
+            rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p - 8);
         }
     }
     action parse_string {
@@ -245,7 +245,7 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
                 fexec p + 10;
                 fhold; fbreak;
             } else {
-                rb_enc_raise(EXC_ENCODING eParserError, "%u: unexpected token at '%s'", __LINE__, p);
+                rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p);
             }
         }
         np = JSON_parse_float(json, fpc, pe, result);
@@ -447,7 +447,7 @@ static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *resul
     if(cs >= JSON_array_first_final) {
         return p + 1;
     } else {
-        rb_enc_raise(EXC_ENCODING eParserError, "%u: unexpected token at '%s'", __LINE__, p);
+        rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p);
         return NULL;
     }
 }
@@ -504,7 +504,7 @@ static VALUE json_string_unescape(char *string, char *stringEnd, int intern, int
                       }
                       rb_enc_raise(
                         EXC_ENCODING eParserError,
-                        "%u: incomplete unicode character escape sequence at '%s'", __LINE__, p
+                        "incomplete unicode character escape sequence at '%s'", p
                       );
                     } else {
                         UTF32 ch = unescape_unicode((unsigned char *) ++pe);
@@ -517,7 +517,7 @@ static VALUE json_string_unescape(char *string, char *stringEnd, int intern, int
                               }
                               rb_enc_raise(
                                 EXC_ENCODING eParserError,
-                                "%u: incomplete surrogate pair at '%s'", __LINE__, p
+                                "incomplete surrogate pair at '%s'", p
                                 );
                             }
                             if (pe[0] == '\\' && pe[1] == 'u') {
@@ -856,7 +856,7 @@ static VALUE cParser_parse(VALUE self)
   if (cs >= JSON_first_final && p == pe) {
     return result;
   } else {
-    rb_enc_raise(EXC_ENCODING eParserError, "%u: unexpected token at '%s'", __LINE__, p);
+    rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p);
     return Qnil;
   }
 }


### PR DESCRIPTION
It makes testing for JSON errors very tedious. You either have to use a Regexp or to regularly update all your assertions when JSON is upgraded.

```
--- expected
+++ actual
@@ -1 +1 @@
-"is invalid JSON: 809: unexpected token at 'FAIL'"
+"is invalid JSON: 859: unexpected token at 'FAIL'"
```

This is what happened to me today and prompted this PR.

cc @nurse @hsbt @tenderlove 