### PR TITLE
Add :value_space option to Generator::State

### DIFF
--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -56,6 +56,8 @@ static char *fstrndup(const char *ptr, unsigned long len);
 /* ruby api and some helpers */
 
 typedef struct JSON_Generator_StateStruct {
+    char *value_space;
+    long value_space_len;
     char *indent;
     long indent_len;
     char *space;

--- a/lib/json/pure/generator.rb
+++ b/lib/json/pure/generator.rb
@@ -111,6 +111,7 @@ module JSON
         # _opts_ can have the following keys:
         #
         # * *indent*: a string used to indent levels (default: ''),
+        # * *value_space: a string that is put after, a , delimiter(default: ''),
         # * *space*: a string that is put after, a : or , delimiter (default: ''),
         # * *space_before*: a string that is put before a : pair delimiter (default: ''),
         # * *object_nl*: a string that is put at the end of a JSON object (default: ''),
@@ -132,8 +133,13 @@ module JSON
           @ascii_only            = false
           @escape_slash          = false
           @buffer_initial_length = 1024
+          @value_space           = ''
           configure opts
         end
+
+        # This string is used to insert a space after value-separator between the values in a JSON
+        # string.
+        attr_accessor :value_space
 
         # This string is used to indent levels in the JSON text.
         attr_accessor :indent
@@ -220,6 +226,7 @@ module JSON
           @indent                = opts[:indent] if opts.key?(:indent)
           @space                 = opts[:space] if opts.key?(:space)
           @space_before          = opts[:space_before] if opts.key?(:space_before)
+          @value_space           = opts[:value_space] if opts.key?(:value_space)
           @object_nl             = opts[:object_nl] if opts.key?(:object_nl)
           @array_nl              = opts[:array_nl] if opts.key?(:array_nl)
           @allow_nan             = !!opts[:allow_nan] if opts.key?(:allow_nan)
@@ -311,6 +318,7 @@ module JSON
 
           def json_transform(state)
             delim = ','
+            delim << state.value_space
             delim << state.object_nl
             result = '{'
             result << state.object_nl
@@ -356,6 +364,7 @@ module JSON
 
           def json_transform(state)
             delim = ','
+            delim << state.value_space
             delim << state.array_nl
             result = '['
             result << state.array_nl

--- a/tests/json_generator_test.rb
+++ b/tests/json_generator_test.rb
@@ -96,6 +96,10 @@ EOT
 <i>}
 }
 EOT
+
+    state = State.new(:value_space => " ", :space => " ")
+    json = generate({1=>{2=>3,4=>[5,6]}}, state)
+    assert_equal('{"1": {"2": 3, "4": [5, 6]}}', json)
   end
 
   def test_fast_generate
@@ -155,6 +159,7 @@ EOT
       :object_nl             => "\n",
       :space                 => " ",
       :space_before          => "",
+      :value_space           => ""
     }.sort_by { |n,| n.to_s }, state.to_h.sort_by { |n,| n.to_s })
   end
 
@@ -172,6 +177,7 @@ EOT
       :object_nl             => "",
       :space                 => "",
       :space_before          => "",
+      :value_space           => ""
     }.sort_by { |n,| n.to_s }, state.to_h.sort_by { |n,| n.to_s })
   end
 
@@ -189,6 +195,7 @@ EOT
       :object_nl             => "",
       :space                 => "",
       :space_before          => "",
+      :value_space           => ""
     }.sort_by { |n,| n.to_s }, state.to_h.sort_by { |n,| n.to_s })
   end
 


### PR DESCRIPTION
Python's json generator add space after `,` and `:` , for example

```python
import json
params = {"foo": ["bar", "baz"], "bat": {"bam": 0, "bad": 1}}
u = json.dumps(params).encode("utf-8")
print(u)
#b'{"foo": ["bar", "baz"], "bat": {"bam": 0, "bad": 1}}'
```

If ruby need to authenticate signatures  with  a python server  using sha256 and json, it does not work since the result is different, for example.

```python
import json, hashlib
params = {"foo": ["bar", "baz"], "bat": {"bam": 0, "bad": 1}}
u = json.dumps(params).encode("utf-8")
res = hashlib.sha256(u).hexdigest()
print(res)

# b0dcf258b372fde9c89fc1ed658f3e4d05a8972a50472412ad8d525f3892b47e
```

```ruby
require 'json'
require 'digest'
params = {foo: ["bar", "baz"], bat: {bam: 0, bad: 1}}
u = JSON.dump(params)
res = Digest::SHA256.hexdigest(u)
puts res
# a762651dd3269e05ce361819604fc707d7387738b580b859be5ee3b242804cc4
```
So I add an option to add space after comma delim