### PR TITLE
bugfix json/pure mixing escaped with literal unicode raises Encoding::CompatibilityError

### DIFF
--- a/lib/json/pure/parser.rb
+++ b/lib/json/pure/parser.rb
@@ -179,7 +179,7 @@ module JSON
                 bytes << c[6 * i + 2, 2].to_i(16) << c[6 * i + 4, 2].to_i(16)
                 i += 1
               end
-              JSON.iconv('utf-8', 'utf-16be', bytes)
+              JSON.iconv('utf-8', 'utf-16be', bytes).force_encoding(::Encoding::ASCII_8BIT)
             end
           end
           if string.respond_to?(:force_encoding)

--- a/tests/json_parser_test.rb
+++ b/tests/json_parser_test.rb
@@ -114,6 +114,10 @@ class JSONParserTest < Test::Unit::TestCase
     assert_equal(BigDecimal("0.901234567890123456789E1"),JSON.parse('{"foo": 9.01234567890123456789}', decimal_class: BigDecimal)["foo"]      )
   end
 
+  def test_parse_string_mixed_unicode
+    assert_equal(["éé"], JSON.parse("[\"\\u00e9é\"]"))
+  end
+
   if Array.method_defined?(:permutation)
     def test_parse_more_complex_arrays
       a = [ nil, false, true, "foßbar", [ "n€st€d", true ], { "nested" => true, "n€ßt€ð2" => {} }]


### PR DESCRIPTION
mixing \u-escaped unicode with literal unicode characters, like so:

```ruby
JSON::Pure::Parser.new(%(["\\u00e9é"])).parse
```

results in this error:

```
.../gems/json-2.3.1/lib/json/pure/parser.rb:194:in `rescue in parse_string': Caught Encoding::CompatibilityError at ']': incompatible character encodings: UTF-8 and ASCII-8BIT (JSON::ParserError)
```

which comes from here:

```
.../gems/json-2.3.1/lib/json/pure/parser.rb:167:in `gsub': incompatible character encodings: UTF-8 and ASCII-8BIT (Encoding::CompatibilityError)
``` 

I _think_ that forcing the encoding of the gsub result back to ASCII_8BIT is a good fix for this since the StringScanner string is forced to ASCII_8BIT. I can't be entirely certain though; the handling of encoding in this parser is a bit beyond me. 