### PR TITLE
Encode `\uXXXX` unescapes as `ASCII_8BIT`

### DIFF
--- a/lib/json/pure/parser.rb
+++ b/lib/json/pure/parser.rb
@@ -179,7 +179,7 @@ module JSON
                 bytes << c[6 * i + 2, 2].to_i(16) << c[6 * i + 4, 2].to_i(16)
                 i += 1
               end
-              JSON.iconv('utf-8', 'utf-16be', bytes)
+              JSON.iconv('utf-8', 'utf-16be', bytes).force_encoding(::Encoding::ASCII_8BIT)
             end
           end
           if string.respond_to?(:force_encoding)

--- a/tests/json_encoding_test.rb
+++ b/tests/json_encoding_test.rb
@@ -8,6 +8,7 @@ class JSONEncodingTest < Test::Unit::TestCase
   def setup
     @utf_8      = '"© ≠ €!"'
     @ascii_8bit = @utf_8.dup.force_encoding('ascii-8bit')
+    @mixed      = '"© \u2260 €!"'
     @parsed     = "© ≠ €!"
     @generated  = '"\u00a9 \u2260 \u20ac!"'
     if String.method_defined?(:encode)
@@ -29,6 +30,7 @@ class JSONEncodingTest < Test::Unit::TestCase
   def test_parse
     assert_equal @parsed, JSON.parse(@ascii_8bit)
     assert_equal @parsed, JSON.parse(@utf_8)
+    assert_equal @parsed, JSON.parse(@mixed)
     assert_equal @parsed, JSON.parse(@utf_16be)
     assert_equal @parsed, JSON.parse(@utf_16le)
     assert_equal @parsed, JSON.parse(@utf_32be)


### PR DESCRIPTION
This fixes an incompatible encoding issue when the source string mixes
`\uXXXX` escape sequences with unescaped UTF-8 characters:

```
>> JSON::Pure::Parser.new('"\u00e9 é"').parse
/Users/dharsha/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/json-2.6.0/lib/json/pure/parser.rb:208:in `rescue in parse_string': Caught Encoding::CompatibilityError at '': incompatible character encodings: UTF-8 and ASCII-8BIT (JSON::ParserError)
	from /Users/dharsha/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/json-2.6.0/lib/json/pure/parser.rb:169:in `parse_string'
	from /Users/dharsha/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/json-2.6.0/lib/json/pure/parser.rb:231:in `parse_value'
	from /Users/dharsha/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/json-2.6.0/lib/json/pure/parser.rb:123:in `parse'
	from (irb):2:in `<main>'
	from /Users/dharsha/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
	from /Users/dharsha/.rbenv/versions/3.0.2/bin/irb:23:in `load'
	from /Users/dharsha/.rbenv/versions/3.0.2/bin/irb:23:in `<main>'
/Users/dharsha/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/json-2.6.0/lib/json/pure/parser.rb:172:in `gsub': incompatible character encodings: UTF-8 and ASCII-8BIT (Encoding::CompatibilityError)
	from /Users/dharsha/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/json-2.6.0/lib/json/pure/parser.rb:172:in `parse_string'
	from /Users/dharsha/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/json-2.6.0/lib/json/pure/parser.rb:231:in `parse_value'
	from /Users/dharsha/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/json-2.6.0/lib/json/pure/parser.rb:123:in `parse'
	from (irb):2:in `<main>'
	from /Users/dharsha/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
	from /Users/dharsha/.rbenv/versions/3.0.2/bin/irb:23:in `load'
	from /Users/dharsha/.rbenv/versions/3.0.2/bin/irb:23:in `<main>'
```

It looks like `gsub` raises this error when you call it on a
force-encoded ascii-8bit string and replace with a utf-8 one (as is done
in [`convert_encoding`][0] and [`parse_string`][1]):

```
>> "x é".encode('utf-8').force_encoding('ascii-8bit').gsub('x', 'é')
(irb):11:in `gsub': incompatible character encodings: UTF-8 and ASCII-8BIT (Encoding::CompatibilityError)
	from (irb):11:in `<main>'
	from /Users/dharsha/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/irb-1.3.5/exe/irb:11:in `<top (required)>'
	from /Users/dharsha/.rbenv/versions/3.0.2/bin/irb:23:in `load'
	from /Users/dharsha/.rbenv/versions/3.0.2/bin/irb:23:in `<main>'
```

To fix the issue, this adds another `force_encoding` to make the
replacement string encoding match the source one. I believe the behavior
should be the same as `convert_encoding`.

[0]: https://github.com/flori/json/blob/442318643a5a42ca0fe3805b84a5e9dba5b34f73/lib/json/pure/parser.rb#L135-L147
[1]: https://github.com/flori/json/blob/442318643a5a42ca0fe3805b84a5e9dba5b34f73/lib/json/pure/parser.rb#L182