### PR TITLE
Bump JSON::VERSION to 2.6.0.

### DIFF
--- a/lib/json/version.rb
+++ b/lib/json/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 module JSON
   # JSON version
-  VERSION         = '2.5.1'
+  VERSION         = '2.6.0'
   VERSION_ARRAY   = VERSION.split(/\./).map { |x| x.to_i } # :nodoc:
   VERSION_MAJOR   = VERSION_ARRAY[0] # :nodoc:
   VERSION_MINOR   = VERSION_ARRAY[1] # :nodoc:


### PR DESCRIPTION
originally bumped by https://github.com/flori/json/commit/1942689b6719af1371f54814999d25307696f71c