### PR TITLE
Call `super` in `included` hook

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -478,6 +478,7 @@ static VALUE mFloat_to_json(int argc, VALUE *argv, VALUE self)
  */
 static VALUE mString_included_s(VALUE self, VALUE modul) {
     VALUE result = rb_funcall(modul, i_extend, 1, mString_Extend);
+    rb_call_super(1, &modul);
     return result;
 }
 

--- a/tests/json_generator_test.rb
+++ b/tests/json_generator_test.rb
@@ -391,6 +391,29 @@ EOT
     end
   end
 
+  if defined?(JSON::Ext::Generator)
+    def test_string_ext_included_calls_super
+      included = false
+
+      Module.alias_method(:included_orig, :included)
+      Module.define_method(:included) do |base|
+        included_orig(base)
+        included = true
+      end
+
+      Class.new(String) do
+        include JSON::Ext::Generator::GeneratorMethods::String
+      end
+
+      assert included
+    ensure
+      if Module.private_method_defined?(:included_orig)
+        Module.alias_method(:included, :included_orig)
+        Module.remove_method(:included_orig)
+      end
+    end
+  end
+
   if defined?(Encoding)
     def test_nonutf8_encoding
       assert_equal("\"5\u{b0}\"", "5\xb0".force_encoding("iso-8859-1").to_json)


### PR DESCRIPTION
The C extension defines an `included` hook for the `JSON::Ext::Generator::GeneratorMethods::String` module but neglects to call `super` in the hook. This can break the functionality of various other code that rely on the fact that `included` on `Module` will always be called.