### PR TITLE
Remove unknown keyword arg from DateTime.parse

### DIFF
--- a/tests/json_addition_test.rb
+++ b/tests/json_addition_test.rb
@@ -165,7 +165,7 @@ class JSONAdditionTest < Test::Unit::TestCase
 
   def test_utc_datetime
     now = Time.now
-    d = DateTime.parse(now.to_s, :create_additions => true) # usual case
+    d = DateTime.parse(now.to_s) # usual case
     assert_equal d, parse(d.to_json, :create_additions => true)
     d = DateTime.parse(now.utc.to_s) # of = 0
     assert_equal d, parse(d.to_json, :create_additions => true)


### PR DESCRIPTION
This snuck in while addding tests for the `create_additions`
feature. Caught by JRuby when we added the `limit` option to the
Date/DateTime parsing methods, which causes this to be rejected as
an unknown keyword.