### PR TITLE
Make rb_scan_args handle keywords more similar to Ruby methods (#2460)

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -1739,7 +1739,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
     } else {
         json->max_nesting = 100;
         json->allow_nan = 0;
-        json->create_additions = 1;
+        json->create_additions = 0;
         json->create_id = rb_funcall(mJSON, i_create_id, 0);
         json->object_class = Qnil;
         json->array_class = Qnil;

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -152,7 +152,7 @@ module JSON
   # * *object_class*: Defaults to Hash
   # * *array_class*: Defaults to Array
   def parse(source, opts = {})
-    Parser.new(source, opts).parse
+    Parser.new(source, **(opts||{})).parse
   end
 
   # Parse the JSON document _source_ into a Ruby data structure and return it.
@@ -174,8 +174,8 @@ module JSON
     opts = {
       :max_nesting  => false,
       :allow_nan    => true
-    }.update(opts)
-    Parser.new(source, opts).parse
+    }.merge(opts)
+    Parser.new(source, **(opts||{})).parse
   end
 
   # Generate a JSON document from the Ruby data structure _obj_ and return


### PR DESCRIPTION
Making it compatibile with Ruby 2.7.5

Actually just fixing the deprecation notice