### PR TITLE
Fix parser bug for empty string allocation

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -2363,9 +2363,17 @@ static VALUE json_string_unescape(char *string, char *stringEnd, int intern, int
 	char buf[4];
 
 	if (bufferSize > MAX_STACK_BUFFER_SIZE) {
+# ifdef HAVE_RB_ENC_INTERNED_STR
+		bufferStart = buffer = ALLOC_N(char, bufferSize ? bufferSize : 1);
+# else
 		bufferStart = buffer = ALLOC_N(char, bufferSize);
+# endif
 	} else {
+# ifdef HAVE_RB_ENC_INTERNED_STR
+		bufferStart = buffer = ALLOCA_N(char, bufferSize ? bufferSize : 1);
+# else
 		bufferStart = buffer = ALLOCA_N(char, bufferSize);
+# endif
 	}
 
 	while (pe < stringEnd) {

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -462,9 +462,17 @@ static VALUE json_string_unescape(char *string, char *stringEnd, int intern, int
     char buf[4];
 
     if (bufferSize > MAX_STACK_BUFFER_SIZE) {
+# ifdef HAVE_RB_ENC_INTERNED_STR
+      bufferStart = buffer = ALLOC_N(char, bufferSize ? bufferSize : 1);
+# else
       bufferStart = buffer = ALLOC_N(char, bufferSize);
+# endif
     } else {
+# ifdef HAVE_RB_ENC_INTERNED_STR
+      bufferStart = buffer = ALLOCA_N(char, bufferSize ? bufferSize : 1);
+# else
       bufferStart = buffer = ALLOCA_N(char, bufferSize);
+# endif
     }
 
     while (pe < stringEnd) {

--- a/tests/json_parser_test.rb
+++ b/tests/json_parser_test.rb
@@ -84,6 +84,7 @@ class JSONParserTest < Test::Unit::TestCase
     assert_equal({ "a" => 23 }, parse('  { "a"  : 23  } '))
     assert_equal({ "a" => 0.23 }, parse(' { "a"  :  0.23 }  '))
     assert_equal({ "a" => 0.23 }, parse('  {  "a"  :  0.23  }  '))
+    assert_equal({ "" => 123 }, parse('{"":123}'))
   end
 
   def test_parse_numbers


### PR DESCRIPTION
When `HAVE_RB_ENC_INTERNED_STR` is enabled it is possible to pass through a null pointer to `rb_enc_interned_str` resulting in a segfault.

Fixes #495

Kudos to @jeremyevans for identifying the fix