### PR TITLE
tests/ractor_test.rb: make assert_separately available

### DIFF
--- a/tests/ractor_test.rb
+++ b/tests/ractor_test.rb
@@ -3,6 +3,8 @@
 
 require 'test_helper'
 
+require_relative './lib/helper'
+
 class JSONInRactorTest < Test::Unit::TestCase
   def test_generate
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")


### PR DESCRIPTION
Require tests/lib/helper.rb to avoid:

NoMethodError: undefined method `assert_separately'

This issue has been seen in Debian and Ubuntu and fixed with the proposed patch.