### PR TITLE
Fix "unexpected token" offset for Infinity

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -587,7 +587,7 @@ tr25:
         if (json->allow_nan) {
             *result = CInfinity;
         } else {
-            rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p - 8);
+            rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p - 7);
         }
     }
 	goto st29;

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -229,7 +229,7 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
         if (json->allow_nan) {
             *result = CInfinity;
         } else {
-            rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p - 8);
+            rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p - 7);
         }
     }
     action parse_string {

--- a/tests/json_ext_parser_test.rb
+++ b/tests/json_ext_parser_test.rb
@@ -3,6 +3,8 @@ require_relative 'test_helper'
 
 class JSONExtParserTest < Test::Unit::TestCase
   if defined?(JSON::Ext::Parser)
+    include JSON
+
     def test_allocate
       parser = JSON::Ext::Parser.new("{}")
       assert_raise(TypeError, '[ruby-core:35079]') do
@@ -10,6 +12,23 @@ class JSONExtParserTest < Test::Unit::TestCase
       end
       parser = JSON::Ext::Parser.allocate
       assert_raise(TypeError, '[ruby-core:35079]') { parser.source }
+    end
+
+    def test_error_messages
+      ex = assert_raise(ParserError) { parse('Infinity') }
+      assert_equal "unexpected token at 'Infinity'", ex.message
+
+      unless RUBY_PLATFORM =~ /java/
+        ex = assert_raise(ParserError) { parse('-Infinity') }
+        assert_equal "unexpected token at '-Infinity'", ex.message
+      end
+
+      ex = assert_raise(ParserError) { parse('NaN') }
+      assert_equal "unexpected token at 'NaN'", ex.message
+    end
+
+    def parse(json)
+      JSON::Ext::Parser.new(json).parse
     end
   end
 end


### PR DESCRIPTION
Previously in the JSON::Ext parser, when we encountered an "Infinity" token (and we weren't allowing `NaN`/`Infinity`) we would try to display the "unexpected token" at the character before.

This was found by OSS-Fuzz due to its buffer underflow of exactly 1 byte. Due to low impact this isn't being tracked as a security issue.