### PR TITLE
Fix homepage url in gemspec

### DIFF
--- a/json-java.gemspec
+++ b/json-java.gemspec
@@ -14,12 +14,12 @@ spec = Gem::Specification.new do |s|
 
   s.files = Dir["lib/**/*", "LICENSE"]
 
-  s.homepage = "http://flori.github.com/json"
+  s.homepage = "https://flori.github.io/json"
   s.metadata = {
       'bug_tracker_uri'   => 'https://github.com/flori/json/issues',
       'changelog_uri'     => 'https://github.com/flori/json/blob/master/CHANGES.md',
-      'documentation_uri' => 'http://flori.github.io/json/doc/index.html',
-      'homepage_uri'      => 'http://flori.github.io/json/',
+      'documentation_uri' => 'https://flori.github.io/json/doc/index.html',
+      'homepage_uri'      => s.homepage,
       'source_code_uri'   => 'https://github.com/flori/json',
       'wiki_uri'          => 'https://github.com/flori/json/wiki'
   }

--- a/json.gemspec
+++ b/json.gemspec
@@ -53,12 +53,12 @@ Gem::Specification.new do |s|
     "lib/json/pure/parser.rb",
     "lib/json/version.rb",
   ]
-  s.homepage = "http://flori.github.com/json"
+  s.homepage = "https://flori.github.io/json"
   s.metadata = {
     'bug_tracker_uri'   => 'https://github.com/flori/json/issues',
     'changelog_uri'     => 'https://github.com/flori/json/blob/master/CHANGES.md',
-    'documentation_uri' => 'http://flori.github.io/json/doc/index.html',
-    'homepage_uri'      => 'http://flori.github.io/json/',
+    'documentation_uri' => 'https://flori.github.io/json/doc/index.html',
+    'homepage_uri'      => s.homepage,
     'source_code_uri'   => 'https://github.com/flori/json',
     'wiki_uri'          => 'https://github.com/flori/json/wiki'
   }

--- a/json_pure.gemspec
+++ b/json_pure.gemspec
@@ -41,12 +41,12 @@ Gem::Specification.new do |s|
     "lib/json/pure/parser.rb".freeze,
     "lib/json/version.rb".freeze,
   ]
-  s.homepage = "http://flori.github.com/json".freeze
+  s.homepage = "https://flori.github.io/json".freeze
   s.metadata = {
     'bug_tracker_uri'   => 'https://github.com/flori/json/issues',
     'changelog_uri'     => 'https://github.com/flori/json/blob/master/CHANGES.md',
-    'documentation_uri' => 'http://flori.github.io/json/doc/index.html',
-    'homepage_uri'      => 'http://flori.github.io/json/',
+    'documentation_uri' => 'https://flori.github.io/json/doc/index.html',
+    'homepage_uri'      => s.homepage,
     'source_code_uri'   => 'https://github.com/flori/json',
     'wiki_uri'          => 'https://github.com/flori/json/wiki'
   }


### PR DESCRIPTION
GitHub Pages now hosted on `*.github.io`

(I visited https://rubygems.org/gems/json a few days ago, the "homepage" URL was `http://flori.github.com/json/` but it has been fixed now.)