### PR TITLE
JRuby requires a minimum of Java 8

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -155,7 +155,7 @@ if defined?(RUBY_ENGINE) and RUBY_ENGINE == 'jruby'
       classpath = (Dir['java/lib/*.jar'] << 'java/src' << JRUBY_JAR) * ':'
       obj = src.sub(/\.java\Z/, '.class')
       file obj => src do
-        sh 'javac', '-classpath', classpath, '-source', '1.6', '-target', '1.6', src
+        sh 'javac', '-classpath', classpath, '-source', '1.8', '-target', '1.8', src
       end
       JAVA_CLASSES << obj
     end


### PR DESCRIPTION
More recent JDKs will reject this command line because 1.6 is too old to build for.