### PR TITLE
Rename JSON::ParseError to JSON:ParserError

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -2958,7 +2958,7 @@ static const char MAYBE_UNUSED(_JSON_nfa_pop_trans)[] = {
 *
 *  Parses the current JSON text _source_ and returns the complete data
 *  structure as a result.
-*  It raises JSON::ParseError if fail to parse.
+*  It raises JSON::ParserError if fail to parse.
 */
 static VALUE cParser_parse(VALUE self)
 {

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -847,7 +847,7 @@ static VALUE cParser_initialize(int argc, VALUE *argv, VALUE self)
  *
  *  Parses the current JSON text _source_ and returns the complete data
  *  structure as a result.
- *  It raises JSON::ParseError if fail to parse.
+ *  It raises JSON::ParserError if fail to parse.
  */
 static VALUE cParser_parse(VALUE self)
 {


### PR DESCRIPTION
This pull request fixes a small typo in a couple of inline comments. The actual error class is `JSON::ParserError`, not `JSON::ParseError`.