### PR TITLE
Skip BigDecimal tests when it's missing to load

### DIFF
--- a/lib/json/add/bigdecimal.rb
+++ b/lib/json/add/bigdecimal.rb
@@ -2,7 +2,10 @@
 unless defined?(::JSON::JSON_LOADED) and ::JSON::JSON_LOADED
   require 'json'
 end
-defined?(::BigDecimal) or require 'bigdecimal'
+begin
+  require 'bigdecimal'
+rescue LoadError
+end
 
 class BigDecimal
   # Import a JSON Marshalled object.
@@ -26,4 +29,4 @@ class BigDecimal
   def to_json(*args)
     as_json.to_json(*args)
   end
-end
+end if defined?(::BigDecimal)

--- a/tests/json_addition_test.rb
+++ b/tests/json_addition_test.rb
@@ -183,7 +183,7 @@ class JSONAdditionTest < Test::Unit::TestCase
   def test_bigdecimal
     assert_equal BigDecimal('3.141', 23), JSON(JSON(BigDecimal('3.141', 23)), :create_additions => true)
     assert_equal BigDecimal('3.141', 666), JSON(JSON(BigDecimal('3.141', 666)), :create_additions => true)
-  end
+  end if defined?(::BigDecimal)
 
   def test_ostruct
     o = OpenStruct.new

--- a/tests/json_parser_test.rb
+++ b/tests/json_parser_test.rb
@@ -4,7 +4,10 @@ require 'test_helper'
 require 'stringio'
 require 'tempfile'
 require 'ostruct'
-require 'bigdecimal'
+begin
+  require 'bigdecimal'
+rescue LoadError
+end
 
 class JSONParserTest < Test::Unit::TestCase
   include JSON
@@ -113,7 +116,7 @@ class JSONParserTest < Test::Unit::TestCase
   def test_parse_bigdecimals
     assert_equal(BigDecimal,                             JSON.parse('{"foo": 9.01234567890123456789}', decimal_class: BigDecimal)["foo"].class)
     assert_equal(BigDecimal("0.901234567890123456789E1"),JSON.parse('{"foo": 9.01234567890123456789}', decimal_class: BigDecimal)["foo"]      )
-  end
+  end if defined?(::BigDecimal)
 
   def test_parse_string_mixed_unicode
     assert_equal(["éé"], JSON.parse("[\"\\u00e9é\"]"))


### PR DESCRIPTION
I have a plan to extract `BigDecimal` from stdlib in the future. We need to handle `LoadError` of `BigDecimal` in some tests.