### PR TITLE
Prevent a warning during test

### DIFF
--- a/tests/json_generator_test.rb
+++ b/tests/json_generator_test.rb
@@ -408,6 +408,7 @@ EOT
       assert included
     ensure
       if Module.private_method_defined?(:included_orig)
+        Module.remove_method(:included)
         Module.alias_method(:included, :included_orig)
         Module.remove_method(:included_orig)
       end


### PR DESCRIPTION
`Module#included` method is redefined without removing the old definition, which causes a warning under verbose mode:

http://rubyci.s3.amazonaws.com/ubuntu/ruby-master/log/20230809T031004Z.log.html.gz
```
[ 9411/24642] JSONGeneratorTest#test_string_ext_included_calls_super/home/chkbuild/chkbuild/tmp/build/20230809T031004Z/ruby/test/json/json_generator_test.rb:411: warning: method redefined; discarding old included
/home/chkbuild/chkbuild/tmp/build/20230809T031004Z/ruby/test/json/json_generator_test.rb:399: warning: previous definition of included was here
 = 0.00 s
 ```