### PR TITLE
Load extension ('json/ext') consistently in test_ext

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -249,7 +249,8 @@ else
   end
 
   desc "Testing library (extension)"
-  task :test_ext => [ :check_env, :compile, :do_test_ext ]
+  task :test_ext => [ :set_env_ext, :check_env, :compile, :do_test_ext ]
+  task(:set_env_ext) { ENV['JSON'] = 'ext' }
 
   UndocumentedTestTask.new do |t|
     t.name = 'do_test_ext'


### PR DESCRIPTION
## Summary

This patch fixes the issue that `rake test` does not actually test
C extension for CRuby.

## The Bug

The `test` task is defined as follows:

https://github.com/flori/json/blob/7ec73ad240d45018f119f5d1a2eaa479ad3f9038/Rakefile#L109-L110

This invokes `:test_pure` and `:test_ext` consecutively.

`:test_pure` assigns `ENV['JSON'] = 'pure'` as follows:

https://github.com/flori/json/blob/7ec73ad240d45018f119f5d1a2eaa479ad3f9038/Rakefile#L97-L98

However, `:test_ext` for CRuby does not change `ENV['JSON']`.

https://github.com/flori/json/blob/7ec73ad240d45018f119f5d1a2eaa479ad3f9038/Rakefile#L252

This lead to `require 'json/pure'` in test_helper.rb, which test only the pure version.

https://github.com/flori/json/blob/7ec73ad240d45018f119f5d1a2eaa479ad3f9038/tests/test_helper.rb#L2-L4

## How to Fix It

I have added `:set_env_ext` to guarantee that `:test_ext` assigns `ENV['JSON'] = 'ext'`.
This is just like `test_ext` in JRuby version