### PR TITLE
[CI] Add Windows mswin job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         - windows-latest
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         include:
+        - { os: windows-latest , ruby: mswin     } # ruby/ruby windows CI
         - { os: ubuntu-latest  , ruby: jruby-9.1 } # Ruby 2.3
         - { os: ubuntu-latest  , ruby: jruby-9.2 } # Ruby 2.5
         - { os: ubuntu-latest  , ruby: jruby-9.3 } # Ruby 2.7

--- a/Rakefile
+++ b/Rakefile
@@ -45,8 +45,14 @@ JAVA_CLASSES        = []
 JRUBY_PARSER_JAR    = File.expand_path("lib/json/ext/parser.jar")
 JRUBY_GENERATOR_JAR = File.expand_path("lib/json/ext/generator.jar")
 
-RAGEL_CODEGEN     = %w[rlcodegen rlgen-cd ragel].find(&which)
-RAGEL_DOTGEN      = %w[rlgen-dot rlgen-cd ragel].find(&which)
+if RUBY_PLATFORM =~ /mingw|mswin/
+  # cleans up Windows CI output
+  RAGEL_CODEGEN     = %w[ragel].find(&which)
+  RAGEL_DOTGEN      = %w[ragel].find(&which)
+else
+  RAGEL_CODEGEN     = %w[rlcodegen rlgen-cd ragel].find(&which)
+  RAGEL_DOTGEN      = %w[rlgen-dot rlgen-cd ragel].find(&which)
+end
 
 desc "Installing library (pure)"
 task :install_pure => :version do


### PR DESCRIPTION
Adding mswin will help with the ruby/ruby 'windows' CI

Windows logs a bunch of junk when running the following in the Rakefile:
```ruby
RAGEL_CODEGEN     = %w[rlcodegen rlgen-cd ragel].find(&which)
RAGEL_DOTGEN      = %w[rlgen-dot rlgen-cd ragel].find(&which)
```
Windows has ragel installed, so added a conditional so it only looks for that...