### PR TITLE
JSON.dump: handle unenclosed hashes regression

### DIFF
--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -611,7 +611,7 @@ module JSON
   #   puts File.read(path)
   # Output:
   #   {"foo":[0,1],"bar":{"baz":2,"bat":3},"bam":"bad"}
-  def dump(obj, anIO = nil, limit = nil, strict: NOT_SET)
+  def dump(obj, anIO = nil, limit = nil, kwargs = nil)
     if anIO and limit.nil?
       anIO = anIO.to_io if anIO.respond_to?(:to_io)
       unless anIO.respond_to?(:write)
@@ -621,7 +621,7 @@ module JSON
     end
     opts = JSON.dump_default_options
     opts = opts.merge(:max_nesting => limit) if limit
-    opts[:strict] = strict if NOT_SET != strict
+    merge_dump_options(opts, **kwargs) if kwargs
     result = generate(obj, opts)
     if anIO
       anIO.write result
@@ -636,6 +636,12 @@ module JSON
   # Encodes string using String.encode.
   def self.iconv(to, from, string)
     string.encode(to, from)
+  end
+
+  private
+
+  def merge_dump_options(opts, strict: NOT_SET)
+    opts[:strict] = strict if NOT_SET != strict
   end
 end
 

--- a/tests/json_generator_test.rb
+++ b/tests/json_generator_test.rb
@@ -62,6 +62,10 @@ EOT
     assert_equal '666', generate(666)
   end
 
+  def test_dump_unenclosed_hash
+    assert_equal '{"a":1,"b":2}', dump(a: 1, b: 2)
+  end
+
   def test_generate_pretty
     json = pretty_generate({})
     assert_equal(<<'EOT'.chomp, json)


### PR DESCRIPTION
Fix: https://github.com/flori/json/issues/553

We can never add keyword arguments to `dump` otherwise existing code using unenclosed hash will break.

cc @hsbt 