### PR TITLE
Use rb_sym2str instead of SYM2ID

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -867,7 +867,7 @@ json_object_i(VALUE key, VALUE val, VALUE _arg)
     if (klass == rb_cString) {
         key_to_s = key;
     } else if (klass == rb_cSymbol) {
-        key_to_s = rb_id2str(SYM2ID(key));
+        key_to_s = rb_sym2str(key);
     } else {
         key_to_s = rb_funcall(key, i_to_s, 0);
     }


### PR DESCRIPTION
This avoids pinning an id to the symbol used if a dynamic symbol is passed in as a hash key.

rb_sym2str is available in Ruby 2.2+ and json depends on >= 2.3.