### PR TITLE
Make OpenStruct support as optional

### DIFF
--- a/lib/json/add/ostruct.rb
+++ b/lib/json/add/ostruct.rb
@@ -2,7 +2,10 @@
 unless defined?(::JSON::JSON_LOADED) and ::JSON::JSON_LOADED
   require 'json'
 end
-require 'ostruct'
+begin
+  require 'ostruct'
+rescue LoadError
+end
 
 class OpenStruct
 
@@ -48,4 +51,4 @@ class OpenStruct
   def to_json(*args)
     as_json.to_json(*args)
   end
-end
+end if defined?(::OpenStruct)

--- a/lib/json/generic_object.rb
+++ b/lib/json/generic_object.rb
@@ -1,5 +1,8 @@
 #frozen_string_literal: false
-require 'ostruct'
+begin
+  require 'ostruct'
+rescue LoadError
+end
 
 module JSON
   class GenericObject < OpenStruct
@@ -67,5 +70,5 @@ module JSON
     def to_json(*a)
       as_json.to_json(*a)
     end
-  end
+  end if defined?(::OpenStruct)
 end

--- a/tests/json_addition_test.rb
+++ b/tests/json_addition_test.rb
@@ -190,7 +190,7 @@ class JSONAdditionTest < Test::Unit::TestCase
     # XXX this won't work; o.foo = { :bar => true }
     o.foo = { 'bar' => true }
     assert_equal o, parse(JSON(o), :create_additions => true)
-  end
+  end if defined?(::OpenStruct)
 
   def test_set
     s = Set.new([:a, :b, :c, :a])

--- a/tests/json_generic_object_test.rb
+++ b/tests/json_generic_object_test.rb
@@ -79,4 +79,4 @@ class JSONGenericObjectTest < Test::Unit::TestCase
   ensure
     JSON::GenericObject.json_creatable = false
   end
-end
+end if defined?(JSON::GenericObject)


### PR DESCRIPTION
see https://github.com/ruby/ostruct/blob/master/lib/ostruct.rb#L136

`OpenStruct` is not recommend to use with performance reason today. We should make `OpenStruct` support as optional.