### PR TITLE
Autoload JSON::GenericObject to avoid require ostruct warning in Ruby 3.4

### DIFF
--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -1,8 +1,9 @@
 #frozen_string_literal: false
 require 'json/version'
-require 'json/generic_object'
 
 module JSON
+  autoload :GenericObject, 'json/generic_object'
+
   NOT_SET = Object.new.freeze
   private_constant :NOT_SET
 


### PR DESCRIPTION
Fixes this warning

```
# ruby -v
ruby 3.4.0dev (2024-04-03T00:55:24Z master b664590c4d) [x86_64-linux]
# echo > Gemfile
# bundle exec ruby -e "require 'json'"
/opt/ruby/lib/ruby/3.4.0+0/json/generic_object.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0. Add ostruct to your Gemfile or gemspec.
```

```
# echo "gem 'rbs'" > Gemfile
# bundle exec irb
(press a[TAB])
irb(main):001> a/opt/ruby/lib/ruby/3.4.0+0/json/generic_object.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0. Add ostruct to your Gemfile or gemspec.       abort    
               alias    
               and      
               at_exit  
               autoload 
               autoload?
```