### PR TITLE
Re-enable truffleruby in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
         - { os: ubuntu-latest  , ruby: jruby-9.2 } # Ruby 2.5
         - { os: ubuntu-latest  , ruby: jruby-9.3 } # Ruby 2.7
         - { os: ubuntu-latest  , ruby: jruby-9.4 } # Ruby 3.1
-        # - { os: macos-latest   , ruby: truffleruby }
-        # - { os: ubuntu-latest  , ruby: truffleruby }
+        - { os: macos-latest   , ruby: truffleruby-head }
+        - { os: ubuntu-latest  , ruby: truffleruby-head }
         exclude:
         - { os: macos-14, ruby: 2.3 }
         - { os: macos-14, ruby: 2.4 }


### PR DESCRIPTION
* https://github.com/oracle/truffleruby/issues/3502 has been fixed.
* Switch to truffleruby-head to get the fix.

See https://github.com/flori/json/pull/575#issuecomment-2014156935