### PR TITLE
Cleanup useless ifdef

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -636,16 +636,12 @@ static size_t State_memsize(const void *ptr)
 #   define RUBY_TYPED_FROZEN_SHAREABLE 0
 #endif
 
-#ifdef NEW_TYPEDDATA_WRAPPER
 static const rb_data_type_t JSON_Generator_State_type = {
     "JSON/Generator/State",
     {NULL, State_free, State_memsize,},
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     0, 0,
-    RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_FROZEN_SHAREABLE,
-#endif
+    RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_FROZEN_SHAREABLE,
 };
-#endif
 
 static VALUE cState_s_allocate(VALUE klass)
 {

--- a/ext/json/ext/generator/generator.h
+++ b/ext/json/ext/generator/generator.h
@@ -166,12 +166,7 @@ static inline void *ruby_zalloc(size_t n)
     return p;
 }
 #endif
-#ifdef TypedData_Make_Struct
+
 static const rb_data_type_t JSON_Generator_State_type;
-#define NEW_TYPEDDATA_WRAPPER 1
-#else
-#define TypedData_Make_Struct(klass, type, ignore, json) Data_Make_Struct(klass, type, NULL, State_free, json)
-#define TypedData_Get_Struct(self, JSON_Generator_State, ignore, json) Data_Get_Struct(self, JSON_Generator_State, json)
-#endif
 
 #endif

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -2097,12 +2097,12 @@ case 9:
 static void JSON_mark(void *ptr)
 {
     JSON_Parser *json = ptr;
-    rb_gc_mark_maybe(json->Vsource);
-    rb_gc_mark_maybe(json->create_id);
-    rb_gc_mark_maybe(json->object_class);
-    rb_gc_mark_maybe(json->array_class);
-    rb_gc_mark_maybe(json->decimal_class);
-    rb_gc_mark_maybe(json->match_string);
+    rb_gc_mark(json->Vsource);
+    rb_gc_mark(json->create_id);
+    rb_gc_mark(json->object_class);
+    rb_gc_mark(json->array_class);
+    rb_gc_mark(json->decimal_class);
+    rb_gc_mark(json->match_string);
 }
 
 static void JSON_free(void *ptr)
@@ -2118,16 +2118,12 @@ static size_t JSON_memsize(const void *ptr)
     return sizeof(*json) + FBUFFER_CAPA(json->fbuffer);
 }
 
-#ifdef NEW_TYPEDDATA_WRAPPER
 static const rb_data_type_t JSON_Parser_type = {
     "JSON/Parser",
     {JSON_mark, JSON_free, JSON_memsize,},
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     0, 0,
     RUBY_TYPED_FREE_IMMEDIATELY,
-#endif
 };
-#endif
 
 static VALUE cJSON_parser_s_allocate(VALUE klass)
 {

--- a/ext/json/ext/parser/parser.h
+++ b/ext/json/ext/parser/parser.h
@@ -85,12 +85,7 @@ static inline void *ruby_zalloc(size_t n)
     return p;
 }
 #endif
-#ifdef TypedData_Make_Struct
+
 static const rb_data_type_t JSON_Parser_type;
-#define NEW_TYPEDDATA_WRAPPER 1
-#else
-#define TypedData_Make_Struct(klass, type, ignore, json) Data_Make_Struct(klass, type, NULL, JSON_free, json)
-#define TypedData_Get_Struct(self, JSON_Parser, ignore, json) Data_Get_Struct(self, JSON_Parser, json)
-#endif
 
 #endif

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -857,12 +857,12 @@ static VALUE cParser_parse(VALUE self)
 static void JSON_mark(void *ptr)
 {
     JSON_Parser *json = ptr;
-    rb_gc_mark_maybe(json->Vsource);
-    rb_gc_mark_maybe(json->create_id);
-    rb_gc_mark_maybe(json->object_class);
-    rb_gc_mark_maybe(json->array_class);
-    rb_gc_mark_maybe(json->decimal_class);
-    rb_gc_mark_maybe(json->match_string);
+    rb_gc_mark(json->Vsource);
+    rb_gc_mark(json->create_id);
+    rb_gc_mark(json->object_class);
+    rb_gc_mark(json->array_class);
+    rb_gc_mark(json->decimal_class);
+    rb_gc_mark(json->match_string);
 }
 
 static void JSON_free(void *ptr)
@@ -878,16 +878,12 @@ static size_t JSON_memsize(const void *ptr)
     return sizeof(*json) + FBUFFER_CAPA(json->fbuffer);
 }
 
-#ifdef NEW_TYPEDDATA_WRAPPER
 static const rb_data_type_t JSON_Parser_type = {
     "JSON/Parser",
     {JSON_mark, JSON_free, JSON_memsize,},
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
     0, 0,
     RUBY_TYPED_FREE_IMMEDIATELY,
-#endif
 };
-#endif
 
 static VALUE cJSON_parser_s_allocate(VALUE klass)
 {


### PR DESCRIPTION
The json gem now requires Ruby 2.3, so there is no point keeping compatibility code for older releases that don't have the TypedData API.

cc @hsbt 