### PR TITLE
Remove outdated ifdef checks

### DIFF
--- a/ext/json/ext/fbuffer/fbuffer.h
+++ b/ext/json/ext/fbuffer/fbuffer.h
@@ -31,12 +31,8 @@
 # define RB_OBJ_STRING(obj) StringValueCStr(obj)
 #endif
 
-#ifdef HAVE_RUBY_ENCODING_H
 #include "ruby/encoding.h"
 #define FORCE_UTF8(obj) rb_enc_associate((obj), rb_utf8_encoding())
-#else
-#define FORCE_UTF8(obj)
-#endif
 
 /* We don't need to guard objects for rbx, so let's do nothing at all. */
 #ifndef RB_GC_GUARD

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -947,23 +947,20 @@ static void generate_json_array(FBuffer *buffer, VALUE Vstate, JSON_Generator_St
     fbuffer_append_char(buffer, ']');
 }
 
-#ifdef HAVE_RUBY_ENCODING_H
 static int enc_utf8_compatible_p(rb_encoding *enc)
 {
     if (enc == rb_usascii_encoding()) return 1;
     if (enc == rb_utf8_encoding()) return 1;
     return 0;
 }
-#endif
 
 static void generate_json_string(FBuffer *buffer, VALUE Vstate, JSON_Generator_State *state, VALUE obj)
 {
     fbuffer_append_char(buffer, '"');
-#ifdef HAVE_RUBY_ENCODING_H
     if (!enc_utf8_compatible_p(rb_enc_get(obj))) {
         obj = rb_str_export_to_enc(obj, rb_utf8_encoding());
     }
-#endif
+
     if (state->ascii_only) {
         convert_UTF8_to_JSON_ASCII(buffer, obj, state->script_safe);
     } else {

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -3,28 +3,6 @@
 #include "../fbuffer/fbuffer.h"
 #include "parser.h"
 
-#if defined HAVE_RUBY_ENCODING_H
-# define EXC_ENCODING rb_utf8_encoding(),
-# ifndef HAVE_RB_ENC_RAISE
-static void
-enc_raise(rb_encoding *enc, VALUE exc, const char *fmt, ...)
-{
-    va_list args;
-    VALUE mesg;
-
-    va_start(args, fmt);
-    mesg = rb_enc_vsprintf(enc, fmt, args);
-    va_end(args);
-
-    rb_exc_raise(rb_exc_new3(exc, mesg));
-}
-#   define rb_enc_raise enc_raise
-# endif
-#else
-# define EXC_ENCODING /* nothing */
-# define rb_enc_raise rb_raise
-#endif
-
 /* unicode */
 
 static const signed char digit_values[256] = {
@@ -555,7 +533,7 @@ tr3:
                 {p = (( p + 10))-1;}
                 p--; {p++; cs = 29; goto _out;}
             } else {
-                rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p);
+                rb_enc_raise(rb_utf8_encoding(), eParserError, "unexpected token at '%s'", p);
             }
         }
         np = JSON_parse_float(json, p, pe, result);
@@ -587,7 +565,7 @@ tr25:
         if (json->allow_nan) {
             *result = CInfinity;
         } else {
-            rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p - 7);
+            rb_enc_raise(rb_utf8_encoding(), eParserError, "unexpected token at '%s'", p - 7);
         }
     }
 	goto st29;
@@ -597,7 +575,7 @@ tr27:
         if (json->allow_nan) {
             *result = CNaN;
         } else {
-            rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p - 2);
+            rb_enc_raise(rb_utf8_encoding(), eParserError, "unexpected token at '%s'", p - 2);
         }
     }
 	goto st29;
@@ -1436,7 +1414,7 @@ case 16:
     if(cs >= JSON_array_first_final) {
         return p + 1;
     } else {
-        rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p);
+        rb_enc_raise(rb_utf8_encoding(), eParserError, "unexpected token at '%s'", p);
         return NULL;
     }
 }
@@ -1500,7 +1478,7 @@ static VALUE json_string_unescape(char *string, char *stringEnd, int intern, int
                         ruby_xfree(bufferStart);
                       }
                       rb_enc_raise(
-                        EXC_ENCODING eParserError,
+                        rb_utf8_encoding(), eParserError,
                         "incomplete unicode character escape sequence at '%s'", p
                       );
                     } else {
@@ -1513,7 +1491,7 @@ static VALUE json_string_unescape(char *string, char *stringEnd, int intern, int
                                 ruby_xfree(bufferStart);
                               }
                               rb_enc_raise(
-                                EXC_ENCODING eParserError,
+                                rb_utf8_encoding(), eParserError,
                                 "incomplete surrogate pair at '%s'", p
                                 );
                             }
@@ -1777,7 +1755,6 @@ case 7:
 
 static VALUE convert_encoding(VALUE source)
 {
-#ifdef HAVE_RUBY_ENCODING_H
   rb_encoding *enc = rb_enc_get(source);
   if (enc == rb_ascii8bit_encoding()) {
     if (OBJ_FROZEN(source)) {
@@ -1787,8 +1764,7 @@ static VALUE convert_encoding(VALUE source)
   } else {
     source = rb_str_conv_enc(source, rb_enc_get(source), rb_utf8_encoding());
   }
-#endif
-    return source;
+  return source;
 }
 
 /*
@@ -2089,7 +2065,7 @@ case 9:
   if (cs >= JSON_first_final && p == pe) {
     return result;
   } else {
-    rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p);
+    rb_enc_raise(rb_utf8_encoding(), eParserError, "unexpected token at '%s'", p);
     return Qnil;
   }
 }

--- a/ext/json/ext/parser/parser.rl
+++ b/ext/json/ext/parser/parser.rl
@@ -1,28 +1,6 @@
 #include "../fbuffer/fbuffer.h"
 #include "parser.h"
 
-#if defined HAVE_RUBY_ENCODING_H
-# define EXC_ENCODING rb_utf8_encoding(),
-# ifndef HAVE_RB_ENC_RAISE
-static void
-enc_raise(rb_encoding *enc, VALUE exc, const char *fmt, ...)
-{
-    va_list args;
-    VALUE mesg;
-
-    va_start(args, fmt);
-    mesg = rb_enc_vsprintf(enc, fmt, args);
-    va_end(args);
-
-    rb_exc_raise(rb_exc_new3(exc, mesg));
-}
-#   define rb_enc_raise enc_raise
-# endif
-#else
-# define EXC_ENCODING /* nothing */
-# define rb_enc_raise rb_raise
-#endif
-
 /* unicode */
 
 static const signed char digit_values[256] = {
@@ -222,14 +200,14 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
         if (json->allow_nan) {
             *result = CNaN;
         } else {
-            rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p - 2);
+            rb_enc_raise(rb_utf8_encoding(), eParserError, "unexpected token at '%s'", p - 2);
         }
     }
     action parse_infinity {
         if (json->allow_nan) {
             *result = CInfinity;
         } else {
-            rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p - 7);
+            rb_enc_raise(rb_utf8_encoding(), eParserError, "unexpected token at '%s'", p - 7);
         }
     }
     action parse_string {
@@ -245,7 +223,7 @@ static char *JSON_parse_object(JSON_Parser *json, char *p, char *pe, VALUE *resu
                 fexec p + 10;
                 fhold; fbreak;
             } else {
-                rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p);
+                rb_enc_raise(rb_utf8_encoding(), eParserError, "unexpected token at '%s'", p);
             }
         }
         np = JSON_parse_float(json, fpc, pe, result);
@@ -447,7 +425,7 @@ static char *JSON_parse_array(JSON_Parser *json, char *p, char *pe, VALUE *resul
     if(cs >= JSON_array_first_final) {
         return p + 1;
     } else {
-        rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p);
+        rb_enc_raise(rb_utf8_encoding(), eParserError, "unexpected token at '%s'", p);
         return NULL;
     }
 }
@@ -511,7 +489,7 @@ static VALUE json_string_unescape(char *string, char *stringEnd, int intern, int
                         ruby_xfree(bufferStart);
                       }
                       rb_enc_raise(
-                        EXC_ENCODING eParserError,
+                        rb_utf8_encoding(), eParserError,
                         "incomplete unicode character escape sequence at '%s'", p
                       );
                     } else {
@@ -524,7 +502,7 @@ static VALUE json_string_unescape(char *string, char *stringEnd, int intern, int
                                 ruby_xfree(bufferStart);
                               }
                               rb_enc_raise(
-                                EXC_ENCODING eParserError,
+                                rb_utf8_encoding(), eParserError,
                                 "incomplete surrogate pair at '%s'", p
                                 );
                             }
@@ -849,7 +827,7 @@ static VALUE cParser_parse(VALUE self)
   if (cs >= JSON_first_final && p == pe) {
     return result;
   } else {
-    rb_enc_raise(EXC_ENCODING eParserError, "unexpected token at '%s'", p);
+    rb_enc_raise(rb_utf8_encoding(), eParserError, "unexpected token at '%s'", p);
     return Qnil;
   }
 }


### PR DESCRIPTION
`json` requires Ruby 2.3, so `HAVE_RUBY_ENCODING_H` and `HAVE_RB_ENC_RAISE` are always true.

cc @hsbt 