### PR TITLE
Use the compiled extension in test

### DIFF
--- a/tests/json_generator_test.rb
+++ b/tests/json_generator_test.rb
@@ -243,7 +243,7 @@ EOT
 
   def test_gc
     if respond_to?(:assert_in_out_err) && !(RUBY_PLATFORM =~ /java/)
-      assert_in_out_err(%w[-rjson], <<-EOS, [], [])
+      assert_in_out_err(%w[-rjson -Ilib -Iext], <<-EOS, [], [])
         bignum_too_long_to_embed_as_string = 1234567890123456789012345
         expect = bignum_too_long_to_embed_as_string.to_s
         GC.stress = true


### PR DESCRIPTION
test_gc fails when using `bundle exec` because it loads JSON from stdlib. It can be seen by showing the `$LOADED_FEATURES` in the test, without using `bundle exec`. This makes sure we use code from lib and ext when running the fork.

```
  test_gc:																															F
================================================================================================================================================================================================================================================================================
Failure: test_gc(JSONGeneratorTest):
  pid 58791 exit 1
  | /Users/etienne/.gem/ruby/3.3.1/gems/bundler-2.5.16/lib/bundler/runtime.rb:304:in `check_for_activated_spec!': You have already activated json 2.7.1, but your Gemfile requires json 2.7.2. Since json is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports json as a default gem. (Gem::LoadError)
  | 	from /Users/etienne/.gem/ruby/3.3.1/gems/bundler-2.5.16/lib/bundler/runtime.rb:25:in `block in setup'
  | 	from /Users/etienne/.gem/ruby/3.3.1/gems/bundler-2.5.16/lib/bundler/spec_set.rb:191:in `each'
  | 	from /Users/etienne/.gem/ruby/3.3.1/gems/bundler-2.5.16/lib/bundler/spec_set.rb:191:in `each'
  | 	from /Users/etienne/.gem/ruby/3.3.1/gems/bundler-2.5.16/lib/bundler/runtime.rb:24:in `map'
  | 	from /Users/etienne/.gem/ruby/3.3.1/gems/bundler-2.5.16/lib/bundler/runtime.rb:24:in `setup'
  | 	from /Users/etienne/.gem/ruby/3.3.1/gems/bundler-2.5.16/lib/bundler.rb:164:in `setup'
  | 	from /Users/etienne/.gem/ruby/3.3.1/gems/bundler-2.5.16/lib/bundler/setup.rb:32:in `block in <top (required)>'
  | 	from /Users/etienne/.gem/ruby/3.3.1/gems/bundler-2.5.16/lib/bundler/ui/shell.rb:159:in `with_level'
  | 	from /Users/etienne/.gem/ruby/3.3.1/gems/bundler-2.5.16/lib/bundler/ui/shell.rb:111:in `silence'
  | 	from /Users/etienne/.gem/ruby/3.3.1/gems/bundler-2.5.16/lib/bundler/setup.rb:32:in `<top (required)>'
  | 	from -:in `require'
  .
```