### PR TITLE
Optimize `fbuffer_inc_capa`

### DIFF
--- a/ext/json/ext/fbuffer/fbuffer.h
+++ b/ext/json/ext/fbuffer/fbuffer.h
@@ -70,6 +70,10 @@ static FBuffer *fbuffer_dup(FBuffer *fb);
 static VALUE fbuffer_to_s(FBuffer *fb);
 #endif
 
+#ifndef RB_UNLIKELY
+#define RB_UNLIKELY(expr) expr
+#endif
+
 static FBuffer *fbuffer_alloc(unsigned long initial_length)
 {
     FBuffer *fb;
@@ -91,20 +95,22 @@ static void fbuffer_clear(FBuffer *fb)
     fb->len = 0;
 }
 
-static void fbuffer_inc_capa(FBuffer *fb, unsigned long requested)
+static inline void fbuffer_inc_capa(FBuffer *fb, unsigned long requested)
 {
-    unsigned long required;
+    if (RB_UNLIKELY(requested > fb->capa - fb->len)) {
+        unsigned long required;
 
-    if (!fb->ptr) {
-        fb->ptr = ALLOC_N(char, fb->initial_length);
-        fb->capa = fb->initial_length;
-    }
+        if (RB_UNLIKELY(!fb->ptr)) {
+            fb->ptr = ALLOC_N(char, fb->initial_length);
+            fb->capa = fb->initial_length;
+        }
 
-    for (required = fb->capa; requested > required - fb->len; required <<= 1);
+        for (required = fb->capa; requested > required - fb->len; required <<= 1);
 
-    if (required > fb->capa) {
-        REALLOC_N(fb->ptr, char, required);
-        fb->capa = required;
+        if (required > fb->capa) {
+            REALLOC_N(fb->ptr, char, required);
+            fb->capa = required;
+        }
     }
 }
 


### PR DESCRIPTION
On my `JSON.dump` benchmark it shows up as 6% of runtime, compared to 40% for `convert_UTF8_to_JSON`.

<img width="889" alt="Capture d’écran 2024-09-02 à 13 48 22" src="https://github.com/user-attachments/assets/36aa2b06-547d-455c-97ac-cb222814c8b6">


Since the vast majority of the time this function is called we still have some buffer capacity, we might as well check that first and skip the expensive loop etc.

With this change my profiler now report this function as 0.7%, so almost 10x better.

<img width="932" alt="Capture d’écran 2024-09-02 à 13 48 34" src="https://github.com/user-attachments/assets/d952ce7b-b2ed-439f-9d87-ac3bf428b8c2">
