### PR TITLE
Restore support for improperly encoded strings

### DIFF
--- a/tests/json_generator_test.rb
+++ b/tests/json_generator_test.rb
@@ -445,15 +445,16 @@ EOT
     assert_includes error.message, "source sequence is illegal/malformed utf-8"
   end
 
-  def test_valid_utf8_in_different_encoding
-    utf8_string = "€™"
-    wrong_encoding_string = utf8_string.b
-    # This behavior is historical. Not necessary desirable.
-    assert_equal utf8_string.to_json, wrong_encoding_string.to_json
-    assert_equal JSON.dump(utf8_string), JSON.dump(wrong_encoding_string)
-  end
-
   if defined?(JSON::Ext::Generator) and RUBY_PLATFORM != "java"
+    def test_valid_utf8_in_different_encoding
+      utf8_string = "€™"
+      wrong_encoding_string = utf8_string.b
+      # This behavior is historical. Not necessary desirable. We should deprecated it.
+      # The pure and java version of the gem already don't behave this way.
+      assert_equal utf8_string.to_json, wrong_encoding_string.to_json
+      assert_equal JSON.dump(utf8_string), JSON.dump(wrong_encoding_string)
+    end
+
     def test_string_ext_included_calls_super
       included = false
 


### PR DESCRIPTION
Since the `json` gem was initially written for Ruby 1.8 before strings had encoding, it used to do its own UTF-8 validation direction on bytes and never really considered the string declared encoding. So passing a ASCII-8BIT string worked as long as the bytes were valid UTF-8

We may want to deprecate this, but we should emit warnings first.

Ref: https://github.com/ruby/json/pull/595#issuecomment-2400412544

FYI: @Earlopain