### PR TITLE
Reduce ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu-20.04
         - ubuntu-22.04
-        - macos-12
         - macos-13
         - macos-14
         - windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby-jruby
-      min_version: 2.3
+      min_version: 2.7
 
   host:
     needs: ruby-versions
@@ -27,14 +27,10 @@ jobs:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         include:
         - { os: windows-latest , ruby: mswin     } # ruby/ruby windows CI
-        - { os: ubuntu-latest  , ruby: jruby-9.3 } # Ruby 2.7
         - { os: ubuntu-latest  , ruby: jruby-9.4 } # Ruby 3.1
         - { os: macos-latest   , ruby: truffleruby-head }
         - { os: ubuntu-latest  , ruby: truffleruby-head }
         exclude:
-        - { os: macos-14, ruby: 2.3 }
-        - { os: macos-14, ruby: 2.4 }
-        - { os: macos-14, ruby: 2.5 }
         - { os: windows-latest, ruby: jruby }
         - { os: windows-latest, ruby: jruby-head }
 
@@ -47,8 +43,6 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           apt-get: ragel
           brew: ragel
-          # only needed for Ruby 2.3
-          mingw: ragel
 
       - run: |
           bundle config --without benchmark

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+* Bump required_ruby_version to 2.7.
+
 ### 2024-10-24 (2.7.3)
 
 * Numerous performance optimizations in `JSON.generate` and `JSON.dump` (up to 2 times faster).

--- a/json.gemspec
+++ b/json.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 version = File.foreach(File.join(__dir__, "lib/json/version.rb")) do |line|
   /^\s*VERSION\s*=\s*'(.*)'/ =~ line and break $1
 end rescue nil
@@ -19,7 +21,7 @@ spec = Gem::Specification.new do |s|
     'wiki_uri'          => 'https://github.com/ruby/json/wiki'
   }
 
-  s.required_ruby_version = Gem::Requirement.new(">= 2.3")
+  s.required_ruby_version = Gem::Requirement.new(">= 2.7")
 
   if java_ext
     s.description = "A JSON implementation as a JRuby extension."

--- a/json_pure.gemspec
+++ b/json_pure.gemspec
@@ -1,50 +1,52 @@
+# frozen_string_literal: true
+
 version = File.foreach(File.join(__dir__, "lib/json/version.rb")) do |line|
   /^\s*VERSION\s*=\s*'(.*)'/ =~ line and break $1
 end rescue nil
 
 Gem::Specification.new do |s|
-  s.name = "json_pure".freeze
+  s.name = "json_pure"
   s.version = version
 
-  s.summary = "JSON Implementation for Ruby".freeze
-  s.description = "This is a JSON implementation in pure Ruby.".freeze
-  s.licenses = ["Ruby".freeze]
-  s.authors = ["Florian Frank".freeze]
-  s.email = "flori@ping.de".freeze
+  s.summary = "JSON Implementation for Ruby"
+  s.description = "This is a JSON implementation in pure Ruby."
+  s.licenses = ["Ruby"]
+  s.authors = ["Florian Frank"]
+  s.email = "flori@ping.de"
 
-  s.extra_rdoc_files = ["README.md".freeze]
-  s.rdoc_options = ["--title".freeze, "JSON implementation for ruby".freeze, "--main".freeze, "README.md".freeze]
+  s.extra_rdoc_files = ["README.md"]
+  s.rdoc_options = ["--title", "JSON implementation for ruby", "--main", "README.md"]
   s.files = [
-    "CHANGES.md".freeze,
-    "COPYING".freeze,
-    "BSDL".freeze,
-    "LEGAL".freeze,
-    "README.md".freeze,
-    "json_pure.gemspec".freeze,
-    "lib/json.rb".freeze,
-    "lib/json/add/bigdecimal.rb".freeze,
-    "lib/json/add/complex.rb".freeze,
-    "lib/json/add/core.rb".freeze,
-    "lib/json/add/date.rb".freeze,
-    "lib/json/add/date_time.rb".freeze,
-    "lib/json/add/exception.rb".freeze,
-    "lib/json/add/ostruct.rb".freeze,
-    "lib/json/add/range.rb".freeze,
-    "lib/json/add/rational.rb".freeze,
-    "lib/json/add/regexp.rb".freeze,
-    "lib/json/add/set.rb".freeze,
-    "lib/json/add/struct.rb".freeze,
-    "lib/json/add/symbol.rb".freeze,
-    "lib/json/add/time.rb".freeze,
-    "lib/json/common.rb".freeze,
-    "lib/json/ext.rb".freeze,
-    "lib/json/generic_object.rb".freeze,
-    "lib/json/pure.rb".freeze,
-    "lib/json/pure/generator.rb".freeze,
-    "lib/json/pure/parser.rb".freeze,
-    "lib/json/version.rb".freeze,
+    "CHANGES.md",
+    "COPYING",
+    "BSDL",
+    "LEGAL",
+    "README.md",
+    "json_pure.gemspec",
+    "lib/json.rb",
+    "lib/json/add/bigdecimal.rb",
+    "lib/json/add/complex.rb",
+    "lib/json/add/core.rb",
+    "lib/json/add/date.rb",
+    "lib/json/add/date_time.rb",
+    "lib/json/add/exception.rb",
+    "lib/json/add/ostruct.rb",
+    "lib/json/add/range.rb",
+    "lib/json/add/rational.rb",
+    "lib/json/add/regexp.rb",
+    "lib/json/add/set.rb",
+    "lib/json/add/struct.rb",
+    "lib/json/add/symbol.rb",
+    "lib/json/add/time.rb",
+    "lib/json/common.rb",
+    "lib/json/ext.rb",
+    "lib/json/generic_object.rb",
+    "lib/json/pure.rb",
+    "lib/json/pure/generator.rb",
+    "lib/json/pure/parser.rb",
+    "lib/json/version.rb",
   ]
-  s.homepage = "https://ruby.github.io/json".freeze
+  s.homepage = "https://ruby.github.io/json"
   s.metadata = {
     'bug_tracker_uri'   => 'https://github.com/ruby/json/issues',
     'changelog_uri'     => 'https://github.com/ruby/json/blob/master/CHANGES.md',
@@ -54,5 +56,5 @@ Gem::Specification.new do |s|
     'wiki_uri'          => 'https://github.com/ruby/json/wiki'
   }
 
-  s.required_ruby_version = Gem::Requirement.new(">= 2.3".freeze)
+  s.required_ruby_version = Gem::Requirement.new(">= 2.7")
 end

--- a/lib/json/pure/generator.rb
+++ b/lib/json/pure/generator.rb
@@ -333,24 +333,17 @@ module JSON
         end
 
         # Assumes !@ascii_only, !@script_safe
-        if Regexp.method_defined?(:match?)
-          private def fast_serialize_string(string, buf) # :nodoc:
-            buf << '"'
-            string = string.encode(::Encoding::UTF_8) unless string.encoding == ::Encoding::UTF_8
-            raise GeneratorError, "source sequence is illegal/malformed utf-8" unless string.valid_encoding?
+        private def fast_serialize_string(string, buf) # :nodoc:
+          buf << '"'
+          string = string.encode(::Encoding::UTF_8) unless string.encoding == ::Encoding::UTF_8
+          raise GeneratorError, "source sequence is illegal/malformed utf-8" unless string.valid_encoding?
 
-            if /["\\\x0-\x1f]/n.match?(string)
-              buf << string.gsub(/["\\\x0-\x1f]/n, MAP)
-            else
-              buf << string
-            end
-            buf << '"'
+          if /["\\\x0-\x1f]/n.match?(string)
+            buf << string.gsub(/["\\\x0-\x1f]/n, MAP)
+          else
+            buf << string
           end
-        else
-          # Ruby 2.3 compatibility
-          private def fast_serialize_string(string, buf) # :nodoc:
-            buf << string.to_json(self)
-          end
+          buf << '"'
         end
 
         # Return the value returned by method +name+.

--- a/lib/json/pure/parser.rb
+++ b/lib/json/pure/parser.rb
@@ -161,11 +161,10 @@ module JSON
         ?u  => nil,
       })
 
-      STR_UMINUS = ''.respond_to?(:-@)
       def parse_string
         if scan(STRING)
           return '' if self[1].empty?
-          string = self[1].gsub(%r((?:\\[\\bfnrt"/]|(?:\\u(?:[A-Fa-f\d]{4}))+|\\[\x20-\xff]))n) do |c|
+          string = self[1].gsub(%r{(?:\\[\\bfnrt"/]|(?:\\u(?:[A-Fa-f\d]{4}))+|\\[\x20-\xff])}n) do |c|
             if u = UNESCAPE_MAP[$&[1]]
               u
             else # \uXXXX
@@ -181,11 +180,7 @@ module JSON
           string.force_encoding(::Encoding::UTF_8)
 
           if @freeze
-            if STR_UMINUS
-              string = -string
-            else
-              string.freeze
-            end
+            string = -string
           end
 
           if @create_additions and @match_string


### PR DESCRIPTION
Fix: https://github.com/ruby/json/pull/639
Fix: https://github.com/ruby/json/issues/638

I couldn't push in @nobu's fork, so opening another PR.

This also bump the `gemspec` requirements and remove compatibility code for older rubies.

2.3 -> 2.7 is quite a bump, I was planning to only bump it to 2.5 or so, but I guess it's OK.