### PR TITLE
Reject invalid number: `-` `-.1` `-e0`

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -990,6 +990,8 @@ static VALUE json_parse_any(JSON_ParserState *state, JSON_ParserConfig *config)
                 raise_parse_error("invalid number: %s", start);
             } else if (RB_UNLIKELY(integer_length > 2 && start[0] == '-' && start[1] == '0')) {
                 raise_parse_error("invalid number: %s", start);
+            } else if (RB_UNLIKELY(integer_length == 1 && start[0] == '-')) {
+                raise_parse_error("invalid number: %s", start);
             }
 
             if ((state->cursor < state->end) && (*state->cursor == '.')) {

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -109,6 +109,9 @@ class JSONParserTest < Test::Unit::TestCase
     assert_raise(JSON::ParserError) { parse('-023.12') }
     assert_raise(JSON::ParserError) { parse('023e12') }
     assert_raise(JSON::ParserError) { parse('-023e12') }
+    assert_raise(JSON::ParserError) { parse('-') }
+    assert_raise(JSON::ParserError) { parse('-.1') }
+    assert_raise(JSON::ParserError) { parse('-e0') }
     assert_equal(23, parse('23'))
     assert_equal(-23, parse('-23'))
     assert_equal_float(3.141, parse('3.141'))


### PR DESCRIPTION
Reject these invalid numbers
```ruby
JSON.parse '-' # => 0
JSON.parse '-.1' # => -0.1
JSON.parse '-e0' # => segmentation fault
```
