### PR TITLE
Bring back JSON::PRETTY_STATE_PROTOTYPE with a deprecation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changes
 
+* Add back `JSON::PRETTY_STATE_PROTOTYPE`. This constant was private API but is used by popular gems like `multi_json`.
+  It now emits a deprecation warning.
+
 ### 2025-04-24 (2.11.1)
 
 * Add back `JSON.restore`, `JSON.unparse`, `JSON.fast_unparse` and `JSON.pretty_unparse`.

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -961,6 +961,24 @@ module JSON
     load(...)
   end
   module_function :restore
+
+  class << self
+    private
+
+    def const_missing(const_name)
+      case const_name
+      when :PRETTY_STATE_PROTOTYPE
+        if RUBY_VERSION >= "3.0"
+          warn "JSON::PRETTY_STATE_PROTOTYPE is deprecated and will be removed in json 3.0.0, just use JSON.pretty_generate", uplevel: 1, category: :deprecated
+        else
+          warn "JSON::PRETTY_STATE_PROTOTYPE is deprecated and will be removed in json 3.0.0, just use JSON.pretty_generate", uplevel: 1
+        end
+        state.new(PRETTY_GENERATE_OPTIONS)
+      else
+        super
+      end
+    end
+  end
   # :startdoc:
 
   # JSON::Coder holds a parser and generator configuration.


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/788

`multi_json` rely on it, even though it was never documented as public API.

Bringing it back as a method so it can emit a deprecation warning.