### PR TITLE
Stop caching the generator state pointer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+* Fix a regression in `JSON.pretty_generate` that could cause indentation to be off once some `#to_json` has been called.
+
 ### 2025-04-24 (2.11.2)
 
 * Add back `JSON::PRETTY_STATE_PROTOTYPE`. This constant was private API but is used by popular gems like `multi_json`.

--- a/test/json/json_common_interface_test.rb
+++ b/test/json/json_common_interface_test.rb
@@ -91,6 +91,30 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
 
   def test_pretty_generate
     assert_equal "[\n  1,\n  2,\n  3\n]", JSON.pretty_generate([ 1, 2, 3 ])
+    assert_equal <<~JSON.strip, JSON.pretty_generate({ a: { b: "f"}, c: "d"})
+      {
+        "a": {
+          "b": "f"
+        },
+        "c": "d"
+      }
+    JSON
+
+    # Cause the state to be spilled on the heap.
+    o = Object.new
+    def o.to_s
+      "Object"
+    end
+    actual = JSON.pretty_generate({ a: { b: o}, c: "d", e: "f"})
+    assert_equal <<~JSON.strip, actual
+      {
+        "a": {
+          "b": "Object"
+        },
+        "c": "d",
+        "e": "f"
+      }
+    JSON
   end
 
   def test_load


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/790

If we end up calling something that spills the state on the heap, the pointer we received is outdated and may be out of sync.