### PR TITLE
Fix i686 builds

### DIFF
--- a/ext/json/ext/generator/extconf.rb
+++ b/ext/json/ext/generator/extconf.rb
@@ -22,7 +22,7 @@ else
       end
     end
 
-    if have_header('x86intrin.h') && have_type('__m128i', headers=['x86intrin.h']) && try_compile(<<~'SRC', opt='-msse2')
+    if have_header('x86intrin.h') && have_type('__m128i', headers=['x86intrin.h']) && try_compile(<<~'SRC')
       #include <x86intrin.h>
       int main() {
           __m128i test = _mm_set1_epi8(32);

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -117,9 +117,9 @@ typedef struct _search_state {
     const char *chunk_end;
     bool has_matches;
 
-#ifdef HAVE_SIMD_NEON
+#if defined(HAVE_SIMD_NEON)
     uint64_t matches_mask;
-#elif HAVE_SIMD_SSE2
+#elif defined(HAVE_SIMD_SSE2)
     int matches_mask;
 #else
 #error "Unknown SIMD Implementation."


### PR DESCRIPTION
We should test compilation with `-msse2` because we need to test with whatever arguments Ruby will be compiled with.

FYI: @samyron 