### PR TITLE
Refactor SIMD ifdefs

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -112,7 +112,7 @@ typedef struct _search_state {
     const char *cursor;
     FBuffer *buffer;
 
-#ifdef JSON_ENABLE_SIMD
+#ifdef HAVE_SIMD
     const char *chunk_base;
     const char *chunk_end;
     bool has_matches;
@@ -124,7 +124,7 @@ typedef struct _search_state {
 #else
 #error "Unknown SIMD Implementation."
 #endif /* HAVE_SIMD_NEON */
-#endif /* JSON_ENABLE_SIMD */
+#endif /* HAVE_SIMD */
 } search_state;
 
 #if (defined(__GNUC__ ) || defined(__clang__))
@@ -261,7 +261,7 @@ static inline void escape_UTF8_char(search_state *search, unsigned char ch_len)
     search->cursor = (search->ptr += ch_len);
 }
 
-#ifdef JSON_ENABLE_SIMD
+#ifdef HAVE_SIMD
 
 static inline FORCE_INLINE char *copy_remaining_bytes(search_state *search, unsigned long vec_len, unsigned long len)
 {
@@ -533,7 +533,7 @@ static inline TARGET_SSE2 FORCE_INLINE unsigned char search_escape_basic_sse2(se
 
 #endif /* HAVE_SIMD_SSE2 */
 
-#endif /* JSON_ENABLE_SIMD */
+#endif /* HAVE_SIMD */
 
 static const unsigned char script_safe_escape_table[256] = {
     // ASCII Control Characters
@@ -1298,11 +1298,11 @@ static void generate_json_string(FBuffer *buffer, struct generate_json_data *dat
     search.cursor = search.ptr;
     search.end = search.ptr + len;
 
-#ifdef JSON_ENABLE_SIMD
+#ifdef HAVE_SIMD
     search.matches_mask = 0;
     search.has_matches = false;
     search.chunk_base = NULL;
-#endif /* JSON_ENABLE_SIMD */
+#endif /* HAVE_SIMD */
 
     switch(rb_enc_str_coderange(obj)) {
         case ENC_CODERANGE_7BIT:
@@ -2170,7 +2170,7 @@ void Init_generator(void)
 
 
     switch(find_simd_implementation()) {
-#ifdef JSON_ENABLE_SIMD
+#ifdef HAVE_SIMD
 #ifdef HAVE_SIMD_NEON
         case SIMD_NEON:
             search_escape_basic_impl = search_escape_basic_neon;
@@ -2181,7 +2181,7 @@ void Init_generator(void)
             search_escape_basic_impl = search_escape_basic_sse2;
             break;
 #endif /* HAVE_SIMD_SSE2 */
-#endif /* JSON_ENABLE_SIMD */
+#endif /* HAVE_SIMD */
         default:
             search_escape_basic_impl = search_escape_basic;
             break;

--- a/ext/json/ext/generator/simd.h
+++ b/ext/json/ext/generator/simd.h
@@ -56,6 +56,7 @@ static SIMD_Implementation find_simd_implementation(void) {
     return SIMD_NEON;
 }
 
+#define HAVE_SIMD 1
 #define HAVE_SIMD_NEON 1
 
 uint8x16x4_t load_uint8x16_4(const unsigned char *table) {
@@ -74,6 +75,7 @@ uint8x16x4_t load_uint8x16_4(const unsigned char *table) {
 #ifdef HAVE_X86INTRIN_H
 #include <x86intrin.h>
 
+#define HAVE_SIMD 1
 #define HAVE_SIMD_SSE2 1
 
 #ifdef HAVE_CPUID_H


### PR DESCRIPTION
The extconf check if SIMD is available, but then later on the `simd.h` header has extra logic to decide if it uses it or not.

e.g. for SSE2 we have:

```
if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) ||
  defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64)
```

Which exclude i686 builds.

Hence if we're not entering that `#if` we can end up with `JSON_ENABLE_SIMD=1` but neither `HAVE_SIMD_NEON` nor `HAVE_SIMD_SSE2`.

So instead of relying on `JSON_ENABLE_SIMD` to check if any SIMD implementation is available, this commit introduce `HAVE_SIMD`.

FYI: @hsbt @samyron 