### PR TITLE
Favor decimal notation over scientific notation for floats

### DIFF
--- a/ext/json/ext/vendor/fpconv.c
+++ b/ext/json/ext/vendor/fpconv.c
@@ -340,7 +340,7 @@ static int emit_digits(char* digits, int ndigits, char* dest, int K, bool neg)
     }
 
     /* write decimal w/o scientific notation */
-    if(K < 0 && (K > -7 || exp < 4)) {
+    if(K < 0 && (K > -7 || exp < 10)) {
         int offset = ndigits - absv(K);
         /* fp < 1.0 -> write leading zero */
         if(offset <= 0) {

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -771,6 +771,14 @@ class JSONGeneratorTest < Test::Unit::TestCase
       values = [-1.0, 1.0, 0.0, 12.2, 7.5 / 3.2, 12.0, 100.0, 1000.0]
       expecteds = ["-1.0", "1.0", "0.0", "12.2", "2.34375", "12.0", "100.0", "1000.0"]
 
+      if RUBY_ENGINE == "jruby"
+        values << 1746861937.7842371
+        expecteds << "1.7468619377842371E9"
+      else
+        values << 1746861937.7842371
+        expecteds << "1746861937.7842371"
+      end
+
       values.zip(expecteds).each do |value, expected|
         assert_equal expected, value.to_json
       end


### PR DESCRIPTION
e.g.
```
JSON.dump(1746861937.7842371)
```

master:
```
"1.7468619377842371e+9"
```

This branch and older json versions:
```
1746861937.7842371
```

In the end it's shorter, and according to `canada.json` benchmark performance is the same.

@radiospiel any objections?

For reference, sidekiq was using a bad regexp to parse JSON and was broken by this change: https://github.com/sidekiq/sidekiq/issues/6700. I'm not considering using scientific notation to workaround that bug, but I think it's better overall.