### PR TITLE
Removed workaround for assert_ractor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   gem "rake"
   gem "rake-compiler"
   gem "test-unit"
-  gem "test-unit-ruby-core"
+  gem "test-unit-ruby-core", ">= 1.0.7"
   gem "all_images", "~> 0" unless RUBY_PLATFORM =~ /java/
 
   if ENV['BENCHMARK']

--- a/test/json/ractor_test.rb
+++ b/test/json/ractor_test.rb
@@ -8,16 +8,6 @@ rescue LoadError
 end
 
 class JSONInRactorTest < Test::Unit::TestCase
-  unless Ractor.method_defined?(:value)
-    module RactorBackport
-      refine Ractor do
-        alias_method :value, :take
-      end
-    end
-
-    using RactorBackport
-  end
-
   def test_generate
     pid = fork do
       r = Ractor.new do


### PR DESCRIPTION
This workaround has been added test-unit-ruby-core. We don't need to care that on our test suite.

https://github.com/ruby/test-unit-ruby-core/blob/master/lib/core_assertions.rb#L375