### PR TITLE
Don't assume `__builtin_cpu_supports` exists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+* Fix support for older compilers without `__builtin_cpu_supports`.
+
 ### Unreleased
 
 ### 2025-05-23 (2.13.0)

--- a/ext/json/ext/simd/conf.rb
+++ b/ext/json/ext/simd/conf.rb
@@ -1,20 +1,24 @@
 case RbConfig::CONFIG['host_cpu']
 when /^(arm|aarch64)/
   # Try to compile a small program using NEON instructions
-  header, type, init = 'arm_neon.h', 'uint8x16_t', 'vdupq_n_u8(32)'
+  header, type, init, extra = 'arm_neon.h', 'uint8x16_t', 'vdupq_n_u8(32)', nil
 when /^(x86_64|x64)/
-  header, type, init = 'x86intrin.h', '__m128i', '_mm_set1_epi8(32)'
+  header, type, init, extra = 'x86intrin.h', '__m128i', '_mm_set1_epi8(32)', 'if (__builtin_cpu_supports("sse2")) { printf("OK"); }'
 end
 if header
-  have_header(header) && try_compile(<<~SRC)
-    #{cpp_include(header)}
-    int main(int argc, char **argv) {
-      #{type} test = #{init};
-      if (argc > 100000) printf("%p", &test);
-      return 0;
-    }
-  SRC
-  $defs.push("-DJSON_ENABLE_SIMD")
+  if have_header(header) && try_compile(<<~SRC, '-Werror=implicit-function-declaration')
+      #{cpp_include(header)}
+      int main(int argc, char **argv) {
+        #{type} test = #{init};
+        #{extra}
+        if (argc > 100000) printf("%p", &test);
+        return 0;
+      }
+    SRC
+    $defs.push("-DJSON_ENABLE_SIMD")
+  else
+    puts "Disable SIMD"
+  end
 end
 
 have_header('cpuid.h')


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/827

On very old compilers it might not exist, at that point might as well skip SIMD entirely.