### PR TITLE
Improve duplicate key warning and errors to include the key name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+* Improve duplicate key warning and errors to include the key name.
+
 ### 2025-07-24 (2.13.1)
 
 * Fix support for older compilers without `__builtin_cpu_supports`.

--- a/java/src/json/ext/ParserConfig.java
+++ b/java/src/json/ext/ParserConfig.java
@@ -2125,10 +2125,10 @@ case 1:
                         if (((RubyHash)result).hasKey(lastName)) {
                             if (config.deprecateDuplicateKey) {
                                 context.runtime.getWarnings().warning(
-                                    "detected duplicate keys in JSON object. This will raise an error in json 3.0 unless enabled via `allow_duplicate_key: true`"
+                                    "detected duplicate key " + name.inspect() + " in JSON object. This will raise an error in json 3.0 unless enabled via `allow_duplicate_key: true`"
                                 );
                             } else {
-                                throw parsingError(context, "duplicate key", p, pe);
+                                throw parsingError(context, "duplicate key" + name.inspect(), p, pe);
                             }
                         }
                     }

--- a/java/src/json/ext/ParserConfig.rl
+++ b/java/src/json/ext/ParserConfig.rl
@@ -692,10 +692,10 @@ public class ParserConfig extends RubyObject {
                         if (((RubyHash)result).hasKey(lastName)) {
                             if (config.deprecateDuplicateKey) {
                                 context.runtime.getWarnings().warning(
-                                    "detected duplicate keys in JSON object. This will raise an error in json 3.0 unless enabled via `allow_duplicate_key: true`"
+                                    "detected duplicate key " + name.inspect() + " in JSON object. This will raise an error in json 3.0 unless enabled via `allow_duplicate_key: true`"
                                 );
                             } else {
-                                throw parsingError(context, "duplicate key", p, pe);
+                                throw parsingError(context, "duplicate key" + name.inspect(), p, pe);
                             }
                         }
                     }

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -333,10 +333,29 @@ class JSONParserTest < Test::Unit::TestCase
 
   def test_parse_duplicate_key
     expected = {"a" => 2}
+    expected_sym = {a: 2}
+
     assert_equal expected, parse('{"a": 1, "a": 2}', allow_duplicate_key: true)
     assert_raise(ParserError) { parse('{"a": 1, "a": 2}', allow_duplicate_key: false) }
-    assert_deprecated_warning(/duplicate keys/) do
+    assert_raise(ParserError) { parse('{"a": 1, "a": 2}', allow_duplicate_key: false, symbolize_names: true) }
+
+    assert_deprecated_warning(/duplicate key "a"/) do
       assert_equal expected, parse('{"a": 1, "a": 2}')
+    end
+    assert_deprecated_warning(/duplicate key "a"/) do
+      assert_equal expected_sym, parse('{"a": 1, "a": 2}', symbolize_names: true)
+    end
+
+    unless RUBY_ENGINE == 'jruby'
+      assert_raise(ParserError) do
+        fake_key = Object.new
+        JSON.load('{"a": 1, "a": 2}', -> (obj) { obj == "a" ? fake_key : obj }, allow_duplicate_key: false)
+      end
+
+      assert_deprecated_warning(/duplicate key #<Object:0x/) do
+        fake_key = Object.new
+        JSON.load('{"a": 1, "a": 2}', -> (obj) { obj == "a" ? fake_key : obj })
+      end
     end
   end
 


### PR DESCRIPTION
Followup: https://github.com/ruby/json/pull/818