### PR TITLE
Fix `JSON::Coder` to cast non-string keys.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 * Fix `JSON.generate` `strict: true` mode to also restrict hash keys.
+* Fix `JSON::Coder` to also invoke block for hash keys that aren't strings nor symbols.
 
 ### 2025-07-28 (2.13.2)
 

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -1029,6 +1029,9 @@ json_object_i(VALUE key, VALUE val, VALUE _arg)
     }
 
     VALUE key_to_s;
+    bool as_json_called = false;
+
+  start:
     switch (rb_type(key)) {
         case T_STRING:
             if (RB_LIKELY(RBASIC_CLASS(key) == rb_cString)) {
@@ -1042,7 +1045,13 @@ json_object_i(VALUE key, VALUE val, VALUE _arg)
             break;
         default:
             if (data->state->strict) {
-                raise_generator_error(key, "%"PRIsVALUE" not allowed in JSON", rb_funcall(key, i_to_s, 0));
+                if (RTEST(data->state->as_json) && !as_json_called) {
+                    key = rb_proc_call_with_block(data->state->as_json, 1, &key, Qnil);
+                    as_json_called = true;
+                    goto start;
+                } else {
+                    raise_generator_error(key, "%"PRIsVALUE" not allowed as object key in JSON", CLASS_OF(key));
+                }
             }
             key_to_s = rb_convert_type(key, T_STRING, "String", "to_s");
             break;

--- a/lib/json/truffle_ruby/generator.rb
+++ b/lib/json/truffle_ruby/generator.rb
@@ -477,7 +477,13 @@ module JSON
               result << state.indent * depth if indent
 
               if state.strict? && !(Symbol === key || String === key)
-                raise GeneratorError.new("#{key.class} not allowed in JSON", value)
+                if state.as_json
+                  key = state.as_json.call(key)
+                end
+
+                unless Symbol === key || String === key
+                  raise GeneratorError.new("#{key.class} not allowed as object key in JSON", value)
+                end
               end
 
               key_str = key.to_s

--- a/test/json/json_coder_test.rb
+++ b/test/json/json_coder_test.rb
@@ -18,6 +18,18 @@ class JSONCoderTest < Test::Unit::TestCase
     assert_raise(JSON::GeneratorError) { coder.dump([Object.new]) }
   end
 
+  def test_json_coder_hash_key
+    obj = Object.new
+    coder = JSON::Coder.new(&:to_s)
+    assert_equal %({#{obj.to_s.inspect}:1}), coder.dump({ obj => 1 })
+
+    coder = JSON::Coder.new { 42 }
+    error = assert_raise JSON::GeneratorError do
+      coder.dump({ obj => 1 })
+    end
+    assert_equal "Integer not allowed as object key in JSON", error.message
+  end
+
   def test_json_coder_options
     coder = JSON::Coder.new(array_nl: "\n") do |object|
       42


### PR DESCRIPTION
Followup: https://github.com/ruby/json/pull/839