### PR TITLE
Fail or warn on duplicated key during generation 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,17 @@
 
 ### Unreleased
 
+* Add new `allow_duplicate_key` generator options. By default a warning is now emitted when a duplicated key is encountered.
+  In `json 3.0` an error will be raised.
+  ```ruby
+  >> Warning[:deprecated] = true
+  >> puts JSON.generate({ foo: 1, "foo" => 2 })
+  (irb):2: warning: detected duplicate key "foo" in {foo: 1, "foo" => 2}.
+  This will raise an error in json 3.0 unless enabled via `allow_duplicate_key: true`
+  {"foo":1,"foo":2}
+  >> JSON.generate({ foo: 1, "foo" => 2 }, allow_duplicate_key: false)
+  detected duplicate key "foo" in {foo: 1, "foo" => 2} (JSON::GeneratorError)
+  ```
 * Fix `JSON.generate` `strict: true` mode to also restrict hash keys.
 * Fix `JSON::Coder` to also invoke block for hash keys that aren't strings nor symbols.
 

--- a/ext/json/ext/fbuffer/fbuffer.h
+++ b/ext/json/ext/fbuffer/fbuffer.h
@@ -24,6 +24,14 @@ typedef unsigned char _Bool;
 #endif
 #endif
 
+#ifndef NOINLINE
+#if defined(__has_attribute) && __has_attribute(noinline)
+#define NOINLINE() __attribute__((noinline))
+#else
+#define NOINLINE()
+#endif
+#endif
+
 #ifndef RB_UNLIKELY
 #define RB_UNLIKELY(expr) expr
 #endif

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -1314,7 +1314,7 @@ static int parser_config_init_i(VALUE key, VALUE val, VALUE data)
     else if (key == sym_symbolize_names)      { config->symbolize_names = RTEST(val); }
     else if (key == sym_freeze)               { config->freeze = RTEST(val); }
     else if (key == sym_on_load)              { config->on_load_proc = RTEST(val) ? val : Qfalse; }
-    else if (key == sym_allow_duplicate_key) { config->on_duplicate_key = RTEST(val) ? JSON_IGNORE : JSON_RAISE; }
+    else if (key == sym_allow_duplicate_key)  { config->on_duplicate_key = RTEST(val) ? JSON_IGNORE : JSON_RAISE; }
     else if (key == sym_decimal_class)        {
         if (RTEST(val)) {
             if (rb_respond_to(val, i_try_convert)) {

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -186,6 +186,25 @@ module JSON
 
     private
 
+    # Called from the extension when a hash has both string and symbol keys
+    def on_mixed_keys_hash(hash, do_raise)
+      set = {}
+      hash.each_key do |key|
+        key_str = key.to_s
+
+        if set[key_str]
+          message = "detected duplicate key #{key_str.inspect} in #{hash.inspect}"
+          if do_raise
+            raise GeneratorError, message
+          else
+            deprecation_warning("#{message}.\nThis will raise an error in json 3.0 unless enabled via `allow_duplicate_key: true`")
+          end
+        else
+          set[key_str] = true
+        end
+      end
+    end
+
     def deprecated_singleton_attr_accessor(*attrs)
       args = RUBY_VERSION >= "3.0" ? ", category: :deprecated" : ""
       attrs.each do |attr|

--- a/lib/json/ext/generator/state.rb
+++ b/lib/json/ext/generator/state.rb
@@ -68,6 +68,11 @@ module JSON
             buffer_initial_length: buffer_initial_length,
           }
 
+          allow_duplicate_key = allow_duplicate_key?
+          unless allow_duplicate_key.nil?
+            result[:allow_duplicate_key] = allow_duplicate_key
+          end
+
           instance_variables.each do |iv|
             iv = iv.to_s[1..-1]
             result[iv.to_sym] = self[iv]

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -234,6 +234,24 @@ class JSONGeneratorTest < Test::Unit::TestCase
       :space                 => "",
       :space_before          => "",
     }.sort_by { |n,| n.to_s }, state.to_h.sort_by { |n,| n.to_s })
+
+    state = JSON::State.new(allow_duplicate_key: true)
+    assert_equal({
+      :allow_duplicate_key   => true,
+      :allow_nan             => false,
+      :array_nl              => "",
+      :as_json               => false,
+      :ascii_only            => false,
+      :buffer_initial_length => 1024,
+      :depth                 => 0,
+      :script_safe           => false,
+      :strict                => false,
+      :indent                => "",
+      :max_nesting           => 100,
+      :object_nl             => "",
+      :space                 => "",
+      :space_before          => "",
+    }.sort_by { |n,| n.to_s }, state.to_h.sort_by { |n,| n.to_s })
   end
 
   def test_allow_nan
@@ -827,5 +845,25 @@ class JSONGeneratorTest < Test::Unit::TestCase
     numbers.each do |number|
       assert_equal "[#{number}]", JSON.generate([number])
     end
+  end
+
+  def test_generate_duplicate_keys_allowed
+    hash = { foo: 1, "foo" => 2 }
+    assert_equal %({"foo":1,"foo":2}), JSON.generate(hash, allow_duplicate_key: true)
+  end
+
+  def test_generate_duplicate_keys_deprecated
+    hash = { foo: 1, "foo" => 2 }
+    assert_deprecated_warning(/allow_duplicate_key/) do
+      assert_equal %({"foo":1,"foo":2}), JSON.generate(hash)
+    end
+  end
+
+  def test_generate_duplicate_keys_disallowed
+    hash = { foo: 1, "foo" => 2 }
+    error = assert_raise JSON::GeneratorError do
+      JSON.generate(hash, allow_duplicate_key: false)
+    end
+    assert_equal %(detected duplicate key "foo" in #{hash.inspect}), error.message
   end
 end


### PR DESCRIPTION
Because both strings and symbols keys are serialized the same, it always has been possible to generate documents with duplicated keys:

```ruby
>> puts JSON.generate({ foo: 1, "foo" => 2 })
{"foo":1,"foo":2}
```

This is pretty much always a mistake and can cause various issues because it's not guaranteed how various JSON parsers will handle this.

Until now I didn't think it was possible to catch such case without tanking performance, hence why I only made the parser more strict.

But I finally found a way to check for duplicated keys cheaply enough.