### PR TITLE
Add coverage on all files

### DIFF
--- a/test/json/test_helper.rb
+++ b/test/json/test_helper.rb
@@ -1,6 +1,5 @@
 $LOAD_PATH.unshift(File.expand_path('../../../ext', __FILE__), File.expand_path('../../../lib', __FILE__))
 
-require "coverage"
 require 'test/unit'
 
 if ENV["JSON_COMPACT"]
@@ -28,31 +27,45 @@ unless defined?(Test::Unit::CoreAssertions)
   Test::Unit::TestCase.include Test::Unit::CoreAssertions
 end
 
-Test::Unit.at_exit do
-  begin
-    require 'simplecov'
-  rescue LoadError
-    # Don't fail Ruby's test suite
-  else
+# The built-in Coverage module (and therefore SimpleCov) need to be activated prior to any require statements.
+# But! SimpleCov requires 'json' before activating Coverage measurement, meaning it misses several files.
+#
+# The solution is to defer any JSON requires from SimpleCov, which works out because we require it ourselves before
+# SimpleCov actually uses it for anything.
+module JSONTestPatch
+  def require(name)
+    if name == 'json'
+      caller_path = caller_locations.first.path
+
+      return false if caller_path.match? %r(/simplecov/)
+    end
+
+    super(name)
+  end
+end
+Kernel.prepend JSONTestPatch
+
+begin
+  require 'simplecov'
+rescue LoadError
+  # Don't fail Ruby's test suite
+else
+  # Override default at_exit or else it will fire when the Rake task process ends early
+  SimpleCov.external_at_exit = true
+  Test::Unit.at_exit do
+    SimpleCov.at_exit_behavior
+  end
+
+  SimpleCov.start do
     # Force SimpleCov to include all files in its report, avoiding accidental require-order misses
-    SimpleCov.track_files 'lib/**/*.rb'
+    track_files 'lib/**/*.rb'
 
-    SimpleCov.add_filter 'lib/json/truffle_ruby' unless RUBY_ENGINE == 'truffleruby'
+    add_filter 'lib/json/truffle_ruby' unless RUBY_ENGINE == 'truffleruby'
 
-    SimpleCov.enable_coverage :branch
-    SimpleCov.primary_coverage :branch
-
-    # must be true for SimpleCov to generate a result at all
-    SimpleCov.running = true
-    coverage = SimpleCov.result
-
-    SimpleCov.write_last_run(coverage)
-    coverage.format!
+    enable_coverage :branch
+    primary_coverage :branch
   end
 end
 
-# Start built-in Coverage directly because SimpleCov depends on JSON gem, wrecking the require order.
-# SimpleCov is still used for the pretty formatting afterward.
-# require is at end of file to avoid coverage monitoring any irrelevant code (eg. Test::Unit)
-Coverage.start(lines: true, branches: true)
+# Require must be after SimpleCov is started for it to see the code
 require 'json'


### PR DESCRIPTION
While #852 adds code coverage, it misses coverage of 5 files:

```
lib/json.rb
lib/json/common.rb
lib/json/version.rb
lib/json/ext.rb
lib/json/ext/generator/state.rb
```

This occurs because the [Coverage](https://docs.ruby-lang.org/en/master/Coverage.html) module (and therefore SimpleCov) need to be started _before_ any require statement to notice a file. SimpleCov itself requires JSON, which causes the above files to be skipped in coverage metrics.

From what I can tell, there are three workaround options: 

**Option 1**
Don't use SimpleCov for the measurement. Just use Coverage module directly and use SimpleCov to only format the output afterward.

The downside to Option 1 is that it loses the ancillary features that SimpleCov provides, That said, the main advantage is that it's the least invasive option. 

**Option 2**
Patch `Kernel.require` to skip `require 'json'` statements coming from SimpleCov, but otherwise behave normally.

This option has the obvious drawback of (lightly) messing with `Kernel`, but it cleans up the use of SimpleCov to its standard API. This might be better for future maintainers to control this tool's behaviour.

**Option 3**
Mess around with defined constants, `$LOADED_FEATURES`, and/or `$LOAD_PATH` to force Ruby to actually run the require twice.

This is what [Docile does](https://github.com/ms-ati/docile/blob/main/spec/spec_helper.rb) to get around the same require-sequencing problem. 

Some of my earlier experiments were to try to get SimpleCov to load the Ruby built-in JSON while the test runner used the head copy (using `$LOAD_PATH` shenanigans and `require_relative`), but that ran into namespace collisions, overrides, and complaints from the C bindings about pointing at the wrong thing. This spooked me off of Option 3's approach; it _might_ be able to be done, but I personally do not have enough experience with Ruby C bindings to have a good feel for how this could break. Docile doesn't use C bindings at all, so they don't have this concern; plus, it gets used in the setup phase, so Option 2 is unavailable to them anyway.

I've implemented both Option 1 and Option 2 in 18150e0d78abfacfdff71f3ffa0e3aaf70d196ad and 11dde98afa685ea80d980352f6905b1adf9e0fdd, respectively, so that the core JSON team has a choice about which approach is preferred. Both of them will produce coverage on all files, solving the original problem.

Option 3 is not provided for the reasons cited above, but could be if someone more familiar with the C bindings can assure me that it wouldn't be fragile.