### PR TITLE
Enable coverage before loading simplecov

### DIFF
--- a/test/json/test_helper.rb
+++ b/test/json/test_helper.rb
@@ -1,5 +1,8 @@
 $LOAD_PATH.unshift(File.expand_path('../../../ext', __FILE__), File.expand_path('../../../lib', __FILE__))
 
+require 'coverage'
+Coverage.start
+
 begin
   require 'simplecov'
 rescue LoadError


### PR DESCRIPTION
Fix: https://github.com/ruby/json/pull/853

Simplecov end up requiring json so we need to start collecting coverage before.