### PR TITLE
`JSON::Coder` callback now recieve a second argument to mark object keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+* `JSON::Coder` callback now receive a second argument to convey whether the object is a hash key.
 * Tuned the floating point number generator to not use scientific notation as agressively.
 
 ### 2025-09-18 (2.14.1)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Instead it is recommended to use the newer `JSON::Coder` API:
 
 ```ruby
 module MyApp
-  API_JSON_CODER = JSON::Coder.new do |object|
+  API_JSON_CODER = JSON::Coder.new do |object, is_object_key|
     case object
     when Time
       object.iso8601(3)
@@ -112,6 +112,8 @@ puts MyApp::API_JSON_CODER.dump(Time.now.utc) # => "2025-01-21T08:41:44.286Z"
 
 The provided block is called for all objects that don't have a native JSON equivalent, and
 must return a Ruby object that has a native JSON equivalent.
+
+It is also called for objects that do have a JSON equivalent, but are used as Hash keys, for instance `{ 1 => 2}`.
 
 ## Combining JSON fragments
 

--- a/java/src/json/ext/Generator.java
+++ b/java/src/json/ext/Generator.java
@@ -396,7 +396,7 @@ public final class Generator {
 
             if (!state.allowNaN()) {
                 if (state.strict() && state.getAsJSON() != null) {
-                    IRubyObject castedValue = state.getAsJSON().call(context, object);
+                    IRubyObject castedValue = state.getAsJSON().call(context, object, context.getRuntime().getFalse());
                     if (castedValue != object) {
                         getHandlerFor(context.runtime, castedValue).generate(context, session, castedValue, buffer);
                         return;
@@ -623,7 +623,7 @@ public final class Generator {
                 GeneratorState state = session.getState(context);
                 if (state.strict()) {
                     if (state.getAsJSON() != null) {
-                        key = state.getAsJSON().call(context, key);
+                        key = state.getAsJSON().call(context, key, context.getRuntime().getTrue());
                         keyStr = castKey(context, key);
                     }
 
@@ -760,7 +760,7 @@ public final class Generator {
         GeneratorState state = session.getState(context);
         if (state.strict()) {
             if (state.getAsJSON() != null) {
-                IRubyObject value = state.getAsJSON().call(context, object);
+                IRubyObject value = state.getAsJSON().call(context, object, context.getRuntime().getFalse());
                 Handler handler = getHandlerFor(context.runtime, value);
                 if (handler == GENERIC_HANDLER) {
                     throw Utils.buildGeneratorError(context, object, value + " returned by as_json not allowed in JSON").toThrowable();

--- a/lib/json/truffle_ruby/generator.rb
+++ b/lib/json/truffle_ruby/generator.rb
@@ -47,6 +47,14 @@ module JSON
 
       SCRIPT_SAFE_ESCAPE_PATTERN = /[\/"\\\x0-\x1f\u2028-\u2029]/
 
+      def self.native_type?(value) # :nodoc:
+        (false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value)
+      end
+
+      def self.native_key?(key) # :nodoc:
+        (Symbol === key || String === key)
+      end
+
       # Convert a UTF8 encoded Ruby string _string_ to a JSON string, encoded with
       # UTF16 big endian characters as \u????, and return it.
       def self.utf8_to_json(string, script_safe = false) # :nodoc:
@@ -448,10 +456,10 @@ module JSON
             state = State.from_state(state) if state
             if state&.strict?
               value = self
-              if state.strict? && !(false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value)
+              if state.strict? && !Generator.native_type?(value)
                 if state.as_json
                   value = state.as_json.call(value, false)
-                  unless false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value
+                  unless Generator.native_type?(value)
                     raise GeneratorError.new("#{value.class} returned by #{state.as_json} not allowed in JSON", value)
                   end
                   value.to_json(state)
@@ -509,12 +517,12 @@ module JSON
               end
               result << state.indent * depth if indent
 
-              if state.strict? && !(Symbol === key || String === key)
+              if state.strict? && !Generator.native_key?(key)
                 if state.as_json
                   key = state.as_json.call(key, true)
                 end
 
-                unless Symbol === key || String === key
+                unless Generator.native_key?(key)
                   raise GeneratorError.new("#{key.class} not allowed as object key in JSON", value)
                 end
               end
@@ -527,10 +535,10 @@ module JSON
               end
 
               result = +"#{result}#{key_json}#{state.space_before}:#{state.space}"
-              if state.strict? && !(false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value)
+              if state.strict? && !Generator.native_type?(value)
                 if state.as_json
                   value = state.as_json.call(value, false)
-                  unless false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value
+                  unless Generator.native_type?(value)
                     raise GeneratorError.new("#{value.class} returned by #{state.as_json} not allowed in JSON", value)
                   end
                   result << value.to_json(state)
@@ -588,10 +596,10 @@ module JSON
             each { |value|
               result << delim unless first
               result << state.indent * depth if indent
-              if state.strict? && !(false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value || Symbol == value)
+              if state.strict? && !Generator.native_type?(value)
                 if state.as_json
                   value = state.as_json.call(value, false)
-                  unless false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value || Symbol === value
+                  unless Generator.native_type?(value)
                     raise GeneratorError.new("#{value.class} returned by #{state.as_json} not allowed in JSON", value)
                   end
                   result << value.to_json(state)

--- a/lib/json/truffle_ruby/generator.rb
+++ b/lib/json/truffle_ruby/generator.rb
@@ -450,7 +450,7 @@ module JSON
               value = self
               if state.strict? && !(false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value)
                 if state.as_json
-                  value = state.as_json.call(value)
+                  value = state.as_json.call(value, false)
                   unless false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value
                     raise GeneratorError.new("#{value.class} returned by #{state.as_json} not allowed in JSON", value)
                   end
@@ -511,7 +511,7 @@ module JSON
 
               if state.strict? && !(Symbol === key || String === key)
                 if state.as_json
-                  key = state.as_json.call(key)
+                  key = state.as_json.call(key, true)
                 end
 
                 unless Symbol === key || String === key
@@ -529,7 +529,7 @@ module JSON
               result = +"#{result}#{key_json}#{state.space_before}:#{state.space}"
               if state.strict? && !(false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value)
                 if state.as_json
-                  value = state.as_json.call(value)
+                  value = state.as_json.call(value, false)
                   unless false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value
                     raise GeneratorError.new("#{value.class} returned by #{state.as_json} not allowed in JSON", value)
                   end
@@ -590,7 +590,7 @@ module JSON
               result << state.indent * depth if indent
               if state.strict? && !(false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value || Symbol == value)
                 if state.as_json
-                  value = state.as_json.call(value)
+                  value = state.as_json.call(value, false)
                   unless false == value || true == value || nil == value || String === value || Array === value || Hash === value || Integer === value || Float === value || Fragment === value || Symbol === value
                     raise GeneratorError.new("#{value.class} returned by #{state.as_json} not allowed in JSON", value)
                   end
@@ -625,7 +625,7 @@ module JSON
               if state.allow_nan?
                 to_s
               elsif state.strict? && state.as_json
-                casted_value = state.as_json.call(self)
+                casted_value = state.as_json.call(self, false)
 
                 if casted_value.equal?(self)
                   raise GeneratorError.new("#{self} not allowed in JSON", self)

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -822,7 +822,7 @@ class JSONGeneratorTest < Test::Unit::TestCase
 
   def test_json_generate_as_json_convert_to_proc
     object = Object.new
-    assert_equal object.object_id.to_json, JSON.generate(object, strict: true, as_json: :object_id)
+    assert_equal object.object_id.to_json, JSON.generate(object, strict: true, as_json: -> (o, is_key) { o.object_id })
   end
 
   def assert_float_roundtrip(expected, actual)


### PR DESCRIPTION
e.g.
```ruby
{ 1 => 2 }
```

The callback will be invoked for `1` as while it has a native JSON equivalent, it's not legal as an object name.

~~TODO: update the JRUby and Truffle implementations.~~