### PR TITLE
Fix concurrent usage of JSON::Coder#dump

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+* Fix `JSON::Coder` to have one dedicated depth counter per invocation.
+  After encountering a circular reference in `JSON::Coder#dump`, any further `#dump` call would raise `JSON::NestingError`.
+
 ### 2025-10-07 (2.15.1)
 
 * Fix incorrect escaping in the JRuby extension when encoding shared strings.

--- a/java/src/json/ext/GeneratorState.java
+++ b/java/src/json/ext/GeneratorState.java
@@ -231,7 +231,7 @@ public class GeneratorState extends RubyObject {
      * the result. If no valid JSON document can be created this method raises
      * a GeneratorError exception.
      */
-    @JRubyMethod(alias="generate_new")
+    @JRubyMethod
     public IRubyObject generate(ThreadContext context, IRubyObject obj, IRubyObject io) {
         IRubyObject result = Generator.generateJson(context, obj, this, io);
         RuntimeInfo info = RuntimeInfo.forRuntime(context.runtime);
@@ -251,9 +251,23 @@ public class GeneratorState extends RubyObject {
         return resultString;
     }
 
-    @JRubyMethod(alias="generate_new")
+    @JRubyMethod
     public IRubyObject generate(ThreadContext context, IRubyObject obj) {
         return generate(context, obj, context.nil);
+    }
+
+    @JRubyMethod
+    public IRubyObject generate_new(ThreadContext context, IRubyObject obj, IRubyObject io) {
+        GeneratorState newState = (GeneratorState)dup();
+        newState.resetDepth();
+        return newState.generate(context, obj, io);
+    }
+
+    @JRubyMethod
+    public IRubyObject generate_new(ThreadContext context, IRubyObject obj) {
+        GeneratorState newState = (GeneratorState)dup();
+        newState.resetDepth();
+        return newState.generate(context, obj, context.nil);
     }
 
     @JRubyMethod(name="[]")
@@ -478,6 +492,10 @@ public class GeneratorState extends RubyObject {
         return vDepth;
     }
 
+    public void resetDepth() {
+        depth = 0;
+    }
+
     private ByteList prepareByteList(ThreadContext context, IRubyObject value) {
         RubyString str = value.convertToString();
         if (str.getEncoding() != UTF8Encoding.INSTANCE) {
@@ -610,7 +628,7 @@ public class GeneratorState extends RubyObject {
     private void checkMaxNesting(ThreadContext context) {
         if (maxNesting != 0 && depth > maxNesting) {
             depth--;
-            throw Utils.newException(context, Utils.M_NESTING_ERROR, "nesting of " + depth + " is too deep");
+            throw Utils.newException(context, Utils.M_NESTING_ERROR, "nesting of " + depth + " is too deep. Did you try to serialize objects with circular references?");
         }
     }
 }

--- a/lib/json/truffle_ruby/generator.rb
+++ b/lib/json/truffle_ruby/generator.rb
@@ -212,7 +212,7 @@ module JSON
           return if @max_nesting.zero?
           current_nesting = depth + 1
           current_nesting > @max_nesting and
-            raise NestingError, "nesting of #{current_nesting} is too deep"
+            raise NestingError, "nesting of #{current_nesting} is too deep. Did you try to serialize objects with circular references?"
         end
 
         # Returns true, if circular data structures are checked,
@@ -345,6 +345,10 @@ module JSON
 
         def generate_new(obj, anIO = nil) # :nodoc:
           dup.generate(obj, anIO)
+        end
+
+        private def initialize_copy(_orig)
+          @depth = 0
         end
 
         # Handles @allow_nan, @buffer_initial_length, other ivars must be the default value (see above)

--- a/test/json/json_coder_test.rb
+++ b/test/json/json_coder_test.rb
@@ -66,4 +66,14 @@ class JSONCoderTest < Test::Unit::TestCase
     end
     assert_include error.message, "NaN not allowed in JSON"
   end
+
+  def test_nesting_recovery
+    coder = JSON::Coder.new
+    ary = []
+    ary << ary
+    assert_raise JSON::NestingError do
+      coder.dump(ary)
+    end
+    assert_equal '{"a":1}', coder.dump({ a: 1 })
+  end
 end


### PR DESCRIPTION
Fix: https://github.com/rails/rails/commit/90616277e3d8fc46c9cf35d6a7470ff1ea0092f7#r168784389

Because the `depth` counter is inside `JSON::State` it can't be used concurrently, and in case of a circular reference the counter may be left at the max value.

The depth counter should be moved outside `JSON_Generator_State` and into `struct generate_json_data`, but it's a larger refactor.

In the meantime, `JSON::Coder` calls `State#generate_new` so I changed that method so that it first copy the state on the stack.

FYI: @chaadow