### PR TITLE
Invoke `as_json` callback for strings with invalid encoding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+* `JSON::Coder` now also yields to the block when encountering strings with invalid encoding.
 * Fix GeneratorError messages to be UTF-8 encoded.
 * Fix memory leak when `Exception` is raised, or `throw` is used during JSON generation.
 * Optimized floating point number parsing by integrating the ryu algorithm (thanks to Josef Šimánek).

--- a/README.md
+++ b/README.md
@@ -113,7 +113,23 @@ puts MyApp::API_JSON_CODER.dump(Time.now.utc) # => "2025-01-21T08:41:44.286Z"
 The provided block is called for all objects that don't have a native JSON equivalent, and
 must return a Ruby object that has a native JSON equivalent.
 
-It is also called for objects that do have a JSON equivalent, but are used as Hash keys, for instance `{ 1 => 2}`.
+It is also called for objects that do have a JSON equivalent, but are used as Hash keys, for instance `{ 1 => 2}`,
+as well as for strings that aren't valid UTF-8:
+
+```ruby
+coder = JSON::Combining.new do |object, is_object_key|
+  case object
+  when String
+    if !string.valid_encoding? || string.encoding != Encoding::UTF_8
+      Base64.encode64(string)
+    else
+      string
+    end
+  else
+    object
+  end
+end
+```
 
 ## Combining JSON fragments
 

--- a/java/src/json/ext/StringEncoder.java
+++ b/java/src/json/ext/StringEncoder.java
@@ -208,6 +208,17 @@ class StringEncoder extends ByteListTranscoder {
         append('"');
     }
 
+    static boolean hasValidEncoding(RubyString str) {
+        switch (str.scanForCodeRange()) {
+            case StringSupport.CR_7BIT:
+                return true;
+            case StringSupport.CR_VALID:
+                return str.getEncoding() == UTF8Encoding.INSTANCE || str.getEncoding() == USASCIIEncoding.INSTANCE;
+            default:
+                return false;
+        }
+    }
+
     static RubyString ensureValidEncoding(ThreadContext context, RubyString str) {
         Encoding encoding = str.getEncoding();
 


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/873

This allow users to encode binary strings if they so wish. e.g. they can use Base64 or similar, or chose to replace invalid characters with something else.