### PR TITLE
parser.c: Optimize `json_parse_digits`

### DIFF
--- a/ext/json/ext/simd/simd.h
+++ b/ext/json/ext/simd/simd.h
@@ -1,3 +1,7 @@
+#ifdef JSON_DEBUG
+#include <assert.h>
+#endif
+
 typedef enum {
     SIMD_NONE,
     SIMD_NEON,
@@ -18,6 +22,10 @@ typedef enum {
 
 static inline uint32_t trailing_zeros64(uint64_t input)
 {
+#ifdef JSON_DEBUG
+    assert(input > 0); // __builtin_ctz(0) is undefined behavior
+#endif
+
 #if HAVE_BUILTIN_CTZLL
     return __builtin_ctzll(input);
 #else
@@ -33,6 +41,10 @@ static inline uint32_t trailing_zeros64(uint64_t input)
 
 static inline int trailing_zeros(int input)
 {
+#ifdef JSON_DEBUG
+    assert(input > 0); // __builtin_ctz(0) is undefined behavior
+#endif
+
 #if HAVE_BUILTIN_CTZLL
     return __builtin_ctz(input);
 #else

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -804,6 +804,10 @@ class JSONParserTest < Test::Unit::TestCase
     end
   end
 
+  def test_parse_whitespace_after_newline
+    assert_equal [], JSON.parse("[\n#{' ' * (8 + 8 + 4 + 3)}]")
+  end
+
   private
 
   def assert_equal_float(expected, actual, delta = 1e-2)


### PR DESCRIPTION
We can use `ctz` builtin to get the number of consecutive digits.

```
== Parsing float parsing (2251051 bytes)
ruby 3.4.6 (2025-09-16 revision dbd83256b1) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after    25.000 i/100ms
Calculating -------------------------------------
               after    231.963 (± 0.0%) i/s    (4.31 ms/i) -      1.175k in   5.065467s

Comparison:
              before:      215.3 i/s
               after:      232.0 i/s - 1.08x  faster
```