### PR TITLE
Deprecate `JSON::State#[]` and `JSON::State#[]=`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+* Deprecate `JSON::State#[]` and `JSON::State#[]=`. Consider using `JSON::Coder` instead.
 * `JSON::Coder` now also yields to the block when encountering strings with invalid encoding.
 * Fix GeneratorError messages to be UTF-8 encoded.
 * Fix memory leak when `Exception` is raised, or `throw` is used during JSON generation.

--- a/lib/json/ext/generator/state.rb
+++ b/lib/json/ext/generator/state.rb
@@ -75,6 +75,8 @@ module JSON
         #
         # Returns the value returned by method +name+.
         def [](name)
+          ::JSON.deprecation_warning("JSON::State#[] is deprecated and will be removed in json 3.0.0")
+
           if respond_to?(name)
             __send__(name)
           else
@@ -87,6 +89,8 @@ module JSON
         #
         # Sets the attribute name to value.
         def []=(name, value)
+          ::JSON.deprecation_warning("JSON::State#[]= is deprecated and will be removed in json 3.0.0")
+
           if respond_to?(name_writer = "#{name}=")
             __send__ name_writer, value
           else

--- a/lib/json/truffle_ruby/generator.rb
+++ b/lib/json/truffle_ruby/generator.rb
@@ -439,6 +439,8 @@ module JSON
 
         # Return the value returned by method +name+.
         def [](name)
+          ::JSON.deprecation_warning("JSON::State#[] is deprecated and will be removed in json 3.0.0")
+
           if respond_to?(name)
             __send__(name)
           else
@@ -448,6 +450,8 @@ module JSON
         end
 
         def []=(name, value)
+          ::JSON.deprecation_warning("JSON::State#[]= is deprecated and will be removed in json 3.0.0")
+
           if respond_to?(name_writer = "#{name}=")
             __send__ name_writer, value
           else

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -183,7 +183,9 @@ class JSONGeneratorTest < Test::Unit::TestCase
     assert_equal('{"1":2}', json)
     s = JSON.state.new
     assert s.check_circular?
-    assert s[:check_circular?]
+    assert_deprecated_warning(/JSON::State/) do
+      assert s[:check_circular?]
+    end
     h = { 1=>2 }
     h[3] = h
     assert_raise(JSON::NestingError) {  generate(h) }
@@ -193,7 +195,9 @@ class JSONGeneratorTest < Test::Unit::TestCase
     a << a
     assert_raise(JSON::NestingError) {  generate(a, s) }
     assert s.check_circular?
-    assert s[:check_circular?]
+    assert_deprecated_warning(/JSON::State/) do
+      assert s[:check_circular?]
+    end
   end
 
   def test_falsy_state
@@ -375,28 +379,32 @@ class JSONGeneratorTest < Test::Unit::TestCase
   end
 
   def test_hash_likeness_set_symbol
-    state = JSON.state.new
-    assert_equal nil, state[:foo]
-    assert_equal nil.class, state[:foo].class
-    assert_equal nil, state['foo']
-    state[:foo] = :bar
-    assert_equal :bar, state[:foo]
-    assert_equal :bar, state['foo']
-    state_hash = state.to_hash
-    assert_kind_of Hash, state_hash
-    assert_equal :bar, state_hash[:foo]
+    assert_deprecated_warning(/JSON::State/) do
+      state = JSON.state.new
+      assert_equal nil, state[:foo]
+      assert_equal nil.class, state[:foo].class
+      assert_equal nil, state['foo']
+      state[:foo] = :bar
+      assert_equal :bar, state[:foo]
+      assert_equal :bar, state['foo']
+      state_hash = state.to_hash
+      assert_kind_of Hash, state_hash
+      assert_equal :bar, state_hash[:foo]
+    end
   end
 
   def test_hash_likeness_set_string
-    state = JSON.state.new
-    assert_equal nil, state[:foo]
-    assert_equal nil, state['foo']
-    state['foo'] = :bar
-    assert_equal :bar, state[:foo]
-    assert_equal :bar, state['foo']
-    state_hash = state.to_hash
-    assert_kind_of Hash, state_hash
-    assert_equal :bar, state_hash[:foo]
+    assert_deprecated_warning(/JSON::State/) do
+      state = JSON.state.new
+      assert_equal nil, state[:foo]
+      assert_equal nil, state['foo']
+      state['foo'] = :bar
+      assert_equal :bar, state[:foo]
+      assert_equal :bar, state['foo']
+      state_hash = state.to_hash
+      assert_kind_of Hash, state_hash
+      assert_equal :bar, state_hash[:foo]
+    end
   end
 
   def test_json_state_to_h_roundtrip


### PR DESCRIPTION
This prevent from freezing and sharing state instances.

If you needs some sort of arguments or extra state to the generator methods, consider using `JSON::Coder` instead.