### PR TITLE
[DOC] Doc for class String

### DIFF
--- a/lib/json/add/string.rb
+++ b/lib/json/add/string.rb
@@ -37,7 +37,7 @@ class String
     object["raw"].pack("C*")
   end
 
-    def to_json_raw_object # :nodoc:
+  def to_json_raw_object # :nodoc:
     {
       JSON.create_id => self.class.name,
       "raw" => unpack("C*"),


### PR DESCRIPTION
Text for `String` class doc, for `String.json_create`, and for `String#to_json_raw`.

`:nodoc:` for `String#to_json_raw_object`, which I don't think users need.