### PR TITLE
Removed old `strnlen` fallback

### DIFF
--- a/ext/json/ext/parser/extconf.rb
+++ b/ext/json/ext/parser/extconf.rb
@@ -6,7 +6,6 @@ have_func("rb_enc_interned_str", "ruby/encoding.h") # RUBY_VERSION >= 3.0
 have_func("rb_str_to_interned_str", "ruby.h") # RUBY_VERSION >= 3.0
 have_func("rb_hash_new_capa", "ruby.h") # RUBY_VERSION >= 3.2
 have_func("rb_hash_bulk_insert", "ruby.h") # Missing on TruffleRuby
-have_func("strnlen", "string.h") # Missing on Solaris 10
 
 append_cflags("-std=c99")
 

--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -296,15 +296,6 @@ static void rvalue_stack_eagerly_release(VALUE handle)
     }
 }
 
-
-#ifndef HAVE_STRNLEN
-static size_t strnlen(const char *s, size_t maxlen)
-{
-    char *p;
-    return ((p = memchr(s, '\0', maxlen)) ? p - s : maxlen);
-}
-#endif
-
 static int convert_UTF32_to_UTF8(char *buf, uint32_t ch)
 {
     int len = 1;


### PR DESCRIPTION
I picked https://github.com/ruby/ruby/commit/4fa6e9938cfb9458abd876ad4219a6648bfe1c96.

This is caused by faiure of https://github.com/ruby/actions/actions/runs/19428976941/job/55583485246#step:17:1092