### PR TITLE
C Extension: Use #if instead of #ifdef for JSON_DEBUG

### DIFF
--- a/ext/json/ext/fbuffer/fbuffer.h
+++ b/ext/json/ext/fbuffer/fbuffer.h
@@ -14,7 +14,7 @@ typedef struct FBufferStruct {
     unsigned long initial_length;
     unsigned long len;
     unsigned long capa;
-#ifdef JSON_DEBUG
+#if JSON_DEBUG
     unsigned long requested;
 #endif
     char *ptr;
@@ -45,14 +45,14 @@ static void fbuffer_stack_init(FBuffer *fb, unsigned long initial_length, char *
         fb->ptr = stack_buffer;
         fb->capa = stack_buffer_size;
     }
-#ifdef JSON_DEBUG
+#if JSON_DEBUG
     fb->requested = 0;
 #endif
 }
 
 static inline void fbuffer_consumed(FBuffer *fb, unsigned long consumed)
 {
-#ifdef JSON_DEBUG
+#if JSON_DEBUG
     if (consumed > fb->requested) {
         rb_bug("fbuffer: Out of bound write");
     }
@@ -122,7 +122,7 @@ static void fbuffer_do_inc_capa(FBuffer *fb, unsigned long requested)
 
 static inline void fbuffer_inc_capa(FBuffer *fb, unsigned long requested)
 {
-#ifdef JSON_DEBUG
+#if JSON_DEBUG
     fb->requested = requested;
 #endif
 
@@ -148,7 +148,7 @@ static inline void fbuffer_append(FBuffer *fb, const char *newstr, unsigned long
 /* Appends a character into a buffer. The buffer needs to have sufficient capacity, via fbuffer_inc_capa(...). */
 static inline void fbuffer_append_reserved_char(FBuffer *fb, char chr)
 {
-#ifdef JSON_DEBUG
+#if JSON_DEBUG
     if (fb->requested < 1) {
         rb_bug("fbuffer: unreserved write");
     }
@@ -174,7 +174,7 @@ static void fbuffer_append_str_repeat(FBuffer *fb, VALUE str, size_t repeat)
 
     fbuffer_inc_capa(fb, repeat * len);
     while (repeat) {
-#ifdef JSON_DEBUG
+#if JSON_DEBUG
         fb->requested = len;
 #endif
         fbuffer_append_reserved(fb, newstr, len);

--- a/ext/json/ext/generator/extconf.rb
+++ b/ext/json/ext/generator/extconf.rb
@@ -6,7 +6,7 @@ if RUBY_ENGINE == 'truffleruby'
 else
   append_cflags("-std=c99")
   $defs << "-DJSON_GENERATOR"
-  $defs << "-DJSON_DEBUG" if ENV["JSON_DEBUG"]
+  $defs << "-DJSON_DEBUG" if ENV.fetch("JSON_DEBUG", "0") != "0"
 
   if enable_config('generator-use-simd', default=!ENV["JSON_DISABLE_SIMD"])
     load __dir__ + "/../simd/conf.rb"

--- a/ext/json/ext/parser/extconf.rb
+++ b/ext/json/ext/parser/extconf.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'mkmf'
 
-$defs << "-DJSON_DEBUG" if ENV["JSON_DEBUG"]
+$defs << "-DJSON_DEBUG" if ENV.fetch("JSON_DEBUG", "0") != "0"
 have_func("rb_enc_interned_str", "ruby/encoding.h") # RUBY_VERSION >= 3.0
 have_func("rb_str_to_interned_str", "ruby.h") # RUBY_VERSION >= 3.0
 have_func("rb_hash_new_capa", "ruby.h") # RUBY_VERSION >= 3.2

--- a/ext/json/ext/vendor/fpconv.c
+++ b/ext/json/ext/vendor/fpconv.c
@@ -29,7 +29,7 @@
 #include <string.h>
 #include <stdint.h>
 
-#ifdef JSON_DEBUG
+#if JSON_DEBUG
 #include <assert.h>
 #endif
 
@@ -472,7 +472,7 @@ static int fpconv_dtoa(double d, char dest[28])
     int ndigits = grisu2(d, digits, &K);
 
     str_len += emit_digits(digits, ndigits, dest + str_len, K, neg);
-#ifdef JSON_DEBUG
+#if JSON_DEBUG
     assert(str_len <= 32);
 #endif
 


### PR DESCRIPTION
While profiling the C extension, I kept hitting code within the `#ifdef JSON_DEBUG`. Using `#ifdef` checks if the identifier is defined, not the value.

I did not have the `JSON_DEBUG` environment variable set but noticed the following in `json.h`:
```
#ifdef RUBY_DEBUG
#ifndef JSON_DEBUG
#define JSON_DEBUG RUBY_DEBUG
#endif
#endif
```

Adding `#error "RUBY_DEBUG defined but not JSON_DEBUG"` after the `#ifndef` and running `rake` outputs the following:

```
In file included from ../../../../../../ext/json/ext/generator/generator.c:1:
../../../../../../ext/json/ext/generator/../json.h:82:2: error: "RUBY_DEBUG defined but not JSON_DEBUG"
   82 | #error "RUBY_DEBUG defined but not JSON_DEBUG"
      |  ^
1 error generated.
```

I should note that I am _not_ running debug build of Ruby. Adding a `printf("RUBY_DEBUG=%lu\n", RUBY_DEBUG);` outputs a lot of `RUBY_DEBUG=0`.

My assumption is we want this code to be excluded if JSON_DEBUG is 0.

