### PR TITLE
Don't emit deprecation warnings in State#to_h in TruffleRuby

### DIFF
--- a/lib/json/truffle_ruby/generator.rb
+++ b/lib/json/truffle_ruby/generator.rb
@@ -312,8 +312,8 @@ module JSON
         def to_h
           result = {}
           instance_variables.each do |iv|
-            iv = iv.to_s[1..-1]
-            result[iv.to_sym] = self[iv]
+            key = iv.to_s[1..-1]
+            result[key.to_sym] = instance_variable_get(iv)
           end
 
           if result[:allow_duplicate_key].nil?


### PR DESCRIPTION
	$ ruby -Ilib -rjson -W:deprecated -e JSON::State.new.to_h |& uniq -c
	  13 -e:1: warning: JSON::State#[] is deprecated and will be removed in json 3.0.0