### PR TITLE
Respect Coder depth

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -1549,7 +1549,7 @@ static VALUE cState_generate_new(int argc, VALUE *argv, VALUE self)
         .buffer = &buffer,
         .vstate = Qfalse,
         .state = state,
-        .depth = 0,
+        .depth = state->depth,
         .obj = obj,
         .func = generate_json
     };

--- a/java/src/json/ext/GeneratorState.java
+++ b/java/src/json/ext/GeneratorState.java
@@ -259,14 +259,12 @@ public class GeneratorState extends RubyObject {
     @JRubyMethod
     public IRubyObject generate_new(ThreadContext context, IRubyObject obj, IRubyObject io) {
         GeneratorState newState = (GeneratorState)dup();
-        newState.resetDepth();
         return newState.generate(context, obj, io);
     }
 
     @JRubyMethod
     public IRubyObject generate_new(ThreadContext context, IRubyObject obj) {
         GeneratorState newState = (GeneratorState)dup();
-        newState.resetDepth();
         return newState.generate(context, obj, context.nil);
     }
 
@@ -502,10 +500,6 @@ public class GeneratorState extends RubyObject {
         checkFrozen();
         depth = RubyNumeric.fix2int(vDepth);
         return vDepth;
-    }
-
-    public void resetDepth() {
-        depth = 0;
     }
 
     private ByteList prepareByteList(ThreadContext context, IRubyObject value) {

--- a/lib/json/truffle_ruby/generator.rb
+++ b/lib/json/truffle_ruby/generator.rb
@@ -352,10 +352,6 @@ module JSON
           dup.generate(obj, anIO)
         end
 
-        private def initialize_copy(_orig)
-          @depth = 0
-        end
-
         # Handles @allow_nan, @buffer_initial_length, other ivars must be the default value (see above)
         private def generate_json(obj, buf)
           case obj

--- a/test/json/json_coder_test.rb
+++ b/test/json/json_coder_test.rb
@@ -134,7 +134,7 @@ class JSONCoderTest < Test::Unit::TestCase
 
   def test_depth
     coder = JSON::Coder.new(object_nl: "\n", array_nl: "\n", space: " ", indent: "  ", depth: 1)
-    assert_equal %({\n  "foo": 42\n}), coder.dump(foo: 42)
+    assert_equal %({\n    "foo": 42\n  }), coder.dump(foo: 42)
   end
 
   def test_nesting_recovery


### PR DESCRIPTION
Builds on #903.

While working on #903, I realized `JSON::Coder` wasn't respecting the depth it's given:

```console
$ ruby -rjson -e 'puts JSON::Coder.new(object_nl: "\n", array_nl: "\n", space: " ", indent: "  ", depth: 1).dump(foo: 42)' \
> -e 'puts JSON::State.new(object_nl: "\n", array_nl: "\n", space: " ", indent: "  ", depth: 1).generate(foo: 42)'
{
  "foo": 42
}
{
    "foo": 42
  }
```

This is not ideal, for example a user could want to emit pretty generated JSON, using Russian-doll caching and `JSON::Fragment` (or a custom solution). To me it's a bug, so I just fixed it, now that `generate_json_data` has its own `depth` it's pretty straightforward: https://github.com/etiennebarrie/json/compare/move-depth-to-generate_json_data...etiennebarrie:json:respect-coder-depth