### PR TITLE
Stop testing on macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-14
+          - macos-latest
           - windows-latest
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         env:
@@ -32,7 +32,7 @@ jobs:
           - { os: ubuntu-24.04-arm, ruby: 3.4 }
           - { os: ubuntu-latest  , ruby: 3.4, env: "JSON_DISABLE_SIMD=1" }
           - { os: ubuntu-latest  , ruby: 3.4, env: "JSON_DEBUG=1" }
-          - { os: macos-13, ruby: 3.4 }
+          - { os: macos-14, ruby: 3.4 }
           - { os: windows-latest , ruby: mswin     } # ruby/ruby windows CI
           - { os: macos-latest  , ruby: jruby-9.4 } # Ruby 3.1
           - { os: ubuntu-latest  , ruby: jruby-9.4 } # Ruby 3.1


### PR DESCRIPTION
These runners are closing down:
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

One thing to note is that macos-13 is x64, whereas macos-14 is arm64. We can't use macos-14-large which runs on x64 because it's for paying customers (at least I couldn't on my fork).

We can use macos-15-intel though, I don't know why that line is here and if it was specifically to test x64 or not, but maybe? https://github.com/ruby/json/commit/5c5c8f16caa6f82764f59f3fb83c343934f5363a