### PR TITLE
Proposal to ship the JSON gem with precompiled binaries

### DIFF
--- a/.github/workflows/cibuildgem.yaml
+++ b/.github/workflows/cibuildgem.yaml
@@ -1,0 +1,87 @@
+name: "Package and release gems with precompiled binaries"
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "If the whole build passes on all platforms, release the gems on RubyGems.org"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  compile:
+    timeout-minutes: 20
+    name: "Cross compile the gem on different ruby versions"
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-22.04"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v5"
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "3.1.7"
+          bundler-cache: true
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "compile"
+  test:
+    timeout-minutes: 20
+    name: "Run the test suite"
+    needs: compile
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-22.04"]
+        rubies: ["3.1", "3.2", "3.3", "3.4"]
+        type: ["cross", "native"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v5"
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "${{ matrix.rubies }}"
+          bundler-cache: true
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "test_${{ matrix.type }}"
+  install:
+    timeout-minutes: 5
+    name: "Verify the gem can be installed"
+    needs: test
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-22.04"]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "3.4.7"
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "install"
+  release:
+    permissions:
+      id-token: write
+      contents: read
+    timeout-minutes: 5
+    if: ${{ inputs.release }}
+    name: "Release all gems with RubyGems"
+    needs: install
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Setup Ruby"
+        uses: "ruby/setup-ruby@v1"
+        with:
+          ruby-version: "3.4.7"
+      - name: "Run cibuildgem"
+        uses: "shopify/cibuildgem/.github/actions/cibuildgem@main"
+        with:
+          step: "release"

--- a/lib/json/ext.rb
+++ b/lib/json/ext.rb
@@ -28,7 +28,14 @@ module JSON
       end
     end
 
-    require 'json/ext/parser'
+    ruby_version = /(\d+\.\d+)/.match(RUBY_VERSION)
+
+    begin
+      require "json/ext/#{ruby_version}/parser"
+    rescue LoadError
+      require "json/ext/parser"
+    end
+
     Ext::Parser::Config = Ext::ParserConfig
     JSON.parser = Ext::Parser
 
@@ -36,7 +43,11 @@ module JSON
       require 'json/truffle_ruby/generator'
       JSON.generator = JSON::TruffleRuby::Generator
     else
-      require 'json/ext/generator'
+      begin
+        require "json/ext/#{ruby_version}/generator"
+      rescue LoadError
+        require "json/ext/generator"
+      end
       JSON.generator = Generator
     end
   end


### PR DESCRIPTION
👋 Hello, sorry if I should have created an issue first, wasn't sure where to propose this.

TL;DR I'd like to propose releasing the json gem with precompiled binaries built for different platforms and different ABI version (fat gem).

I'm currently working on a tool to help the Ruby community ship gems with precompiled binaries with the intent to make `bundle install` much faster for everyone. The main bottleneck when installing gems in a project is the compilation of native extensions.
After testing internally and with private gems, I'd like to get the feedback of a few gem maintainers.

-----------


### What is it

[cibuildgem](https://github.com/Shopify/cibuildgem) modestly tries to follow the same approach as [cibuildwheel](https://cibuildwheel.pypa.io/en/stable/) from the python community. It works by compiling natively using CI runners (GitHub it the only supported vendor for now) and tries to be as easy to setup as possible. The json gem already relies on Rake Compiler for development purposes, and because cibuildgem piggyback on top of Rake Compiler, there is no extra configuration required.

The CI workflow in this commit was generated with the cibuildgem CLI which reads the gemspec and determine what ruby versions needs to be compiled and tested against. This is the resulting CI when this workflow runs: https://github.com/Shopify/json-1/actions/runs/19836110651

The tool is very new and I did many tests internally to make sure that it create binaries that can be used in other environments. For instance, I used it to precompile almost all gems that a new Rails application depends on and pushed them under a different "namespace" on my [RubyGems](https://rubygems.org/profiles/edouardchin), I then confirmed that the rails application was bootable using all those gems (I'm on MacOS). 

I was hoping I could use the json gem and get the feedback of its maintainers in order to continue the development of cibuildgem and improve it.

### Things you may want to know

- On GitHub, the earliest glibc version we can use is 2.35 (using Ubuntu 22). This means that any users that are on a linux distro that comes with a glibc version lower than this will not be able to install the gem with precompiled binaries. They'll have to install the "normal" gem and specify it in their gemfile
(`gem 'json', platform: 'ruby'`).

- This workflow gets triggered manually through the GitHub action page when you are ready to cut a release. You can optionally decide to let the tool do the release on RubyGems (using a chechbox on the GitHub UI). If you'd prefer doing it from your machine, you can download the gems from the GitHub action artifacts.

- The workflow in this commit compile binaries for MacOS silicon and linux x86_64. It should work on windows but I have not tested extensively to be confident. You should also be able to use macos intel and linus arm64 (GitHub started to [offer this recently](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/)).

-----------

If you have any questions, I'm happy to answer! Any feedback would be amazing so feel free to point anything that you'd like to see this tool do or not do 😅 .