### PR TITLE
Don't call `to_json` on the return value of `as_json` for `Float::NAN`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 
 ### Unreleased
 
-* Fixed the parser to no longer ignore invalid escapes in strings.
+* Fix the parser to no longer ignore invalid escapes in strings.
   Only `\"`, `\\`, `\b`, `\f`, `\n`, `\r`, `\t` and `\u` are valid JSON escapes.
+* On TruffleRuby, fix the generator to not call `to_json` on the return value of `as_json` for `Float::NAN`.
 
 ### 2025-11-07 (2.16.0)
 

--- a/lib/json/truffle_ruby/generator.rb
+++ b/lib/json/truffle_ruby/generator.rb
@@ -651,6 +651,9 @@ module JSON
                 if casted_value.equal?(self)
                   raise GeneratorError.new("#{self} not allowed in JSON", self)
                 end
+                unless Generator.native_type?(casted_value)
+                  raise GeneratorError.new("#{casted_value.class} returned by #{state.as_json} not allowed in JSON", casted_value)
+                end
 
                 state.check_max_nesting
                 state.depth += 1

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -883,6 +883,15 @@ class JSONGeneratorTest < Test::Unit::TestCase
     assert_equal object.object_id.to_json, JSON.generate(object, strict: true, as_json: -> (o, is_key) { o.object_id })
   end
 
+  def test_as_json_nan_does_not_call_to_json
+    def (obj = Object.new).to_json(*)
+      "null"
+    end
+    assert_raise(JSON::GeneratorError) do
+      JSON.generate(Float::NAN, strict: true, as_json: proc { obj })
+    end
+  end
+
   def assert_float_roundtrip(expected, actual)
     assert_equal(expected, JSON.generate(actual))
     assert_equal(actual, JSON.parse(JSON.generate(actual)), "JSON: #{JSON.generate(actual)}")


### PR DESCRIPTION
If you use `strict: true` and the return value of `as_json` is not a native JSON type, TruffleRuby may call `to_json` on it, as opposed to CRuby or JRuby.

This only happens for `Float::NAN`, because we were lacking a check before calling `to_json` on the casted value.