### PR TITLE
Improve `JSON.load` and `JSON.unsafe_load` to allow passing options as second argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+* Improve `JSON.load` and `JSON.unsafe_load` to allow passing options as second argument.
 * Fix the parser to no longer ignore invalid escapes in strings.
   Only `\"`, `\\`, `\b`, `\f`, `\n`, `\r`, `\t` and `\u` are valid JSON escapes.
 * On TruffleRuby, fix the generator to not call `to_json` on the return value of `as_json` for `Float::NAN`.

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -550,6 +550,7 @@ module JSON
     :create_additions => nil,
   }
   # :call-seq:
+  #   JSON.unsafe_load(source, options = {}) -> object
   #   JSON.unsafe_load(source, proc = nil, options = {}) -> object
   #
   # Returns the Ruby objects created by parsing the given +source+.
@@ -681,7 +682,12 @@ module JSON
   #
   def unsafe_load(source, proc = nil, options = nil)
     opts = if options.nil?
-      _unsafe_load_default_options
+      if proc && proc.is_a?(Hash)
+        options, proc = proc, nil
+        options
+      else
+        _unsafe_load_default_options
+      end
     else
       _unsafe_load_default_options.merge(options)
     end
@@ -709,6 +715,7 @@ module JSON
   end
 
   # :call-seq:
+  #   JSON.load(source, options = {}) -> object
   #   JSON.load(source, proc = nil, options = {}) -> object
   #
   # Returns the Ruby objects created by parsing the given +source+.
@@ -845,8 +852,18 @@ module JSON
   #      @attributes={"type"=>"Admin", "password"=>"0wn3d"}>}
   #
   def load(source, proc = nil, options = nil)
+    if proc && options.nil? && proc.is_a?(Hash)
+      options = proc
+      proc = nil
+    end
+
     opts = if options.nil?
-      _load_default_options
+      if proc && proc.is_a?(Hash)
+        options, proc = proc, nil
+        options
+      else
+        _load_default_options
+      end
     else
       _load_default_options.merge(options)
     end

--- a/test/json/json_common_interface_test.rb
+++ b/test/json/json_common_interface_test.rb
@@ -149,6 +149,7 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
   def test_load_with_options
     json  = '{ "foo": NaN }'
     assert JSON.load(json, nil, :allow_nan => true)['foo'].nan?
+    assert JSON.load(json, :allow_nan => true)['foo'].nan?
   end
 
   def test_load_null
@@ -213,6 +214,12 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
       '{"foo":[1,2,3],"bar":{"baz":"plop"}}',
     ]
     assert_equal expected, visited
+  end
+
+  def test_unsafe_load_with_options
+    json  = '{ "foo": NaN }'
+    assert JSON.unsafe_load(json, nil, :allow_nan => true)['foo'].nan?
+    assert JSON.unsafe_load(json, :allow_nan => true)['foo'].nan?
   end
 
   def test_unsafe_load_default_options


### PR DESCRIPTION
Otherwise it's very error prone.

I'm experimenting with what `json` 3.0 will be like with the `create_additions` remove, and `JSON.load` no longer considered unsafe.

This came up as a footgun.