### PR TITLE
Fix handling of depth

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,12 @@
 * Improve `JSON.load` and `JSON.unsafe_load` to allow passing options as second argument.
 * Fix the parser to no longer ignore invalid escapes in strings.
   Only `\"`, `\\`, `\b`, `\f`, `\n`, `\r`, `\t` and `\u` are valid JSON escapes.
+* Fixed `JSON::Coder` to use the depth it was initialized with.
 * On TruffleRuby, fix the generator to not call `to_json` on the return value of `as_json` for `Float::NAN`.
+* Fixed handling of `state.depth`: when `to_json` changes `state.depth` but does not restore it, it is reset
+  automatically to its initial value.
+  In particular, when a `NestingError` is raised, `depth` is no longer equal to `max_nesting` after the call to
+  generate, and is reset to its initial value. Similarly when `to_json` raises an exception.
 
 ### 2025-11-07 (2.16.0)
 

--- a/java/src/json/ext/GeneratorState.java
+++ b/java/src/json/ext/GeneratorState.java
@@ -256,18 +256,6 @@ public class GeneratorState extends RubyObject {
         return generate(context, obj, context.nil);
     }
 
-    @JRubyMethod
-    public IRubyObject generate_new(ThreadContext context, IRubyObject obj, IRubyObject io) {
-        GeneratorState newState = (GeneratorState)dup();
-        return newState.generate(context, obj, io);
-    }
-
-    @JRubyMethod
-    public IRubyObject generate_new(ThreadContext context, IRubyObject obj) {
-        GeneratorState newState = (GeneratorState)dup();
-        return newState.generate(context, obj, context.nil);
-    }
-
     @JRubyMethod(name="[]")
     public IRubyObject op_aref(ThreadContext context, IRubyObject vName) {
         String name = vName.asJavaString();

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -1074,7 +1074,7 @@ module JSON
     #
     # Serialize the given object into a \JSON document.
     def dump(object, io = nil)
-      @state.generate_new(object, io)
+      @state.generate(object, io)
     end
     alias_method :generate, :dump
 


### PR DESCRIPTION
This adds a few tests around the handling of depth when an exception (in particular `JSON::NestingError`) is raised during JSON generation. The core idea is that `state.depth` shouldn't be changed when calling `state.generate(obj)` or `obj.to_json(state)`. While we can't be sure in the last case for user-controlled classes, we can reasonably ensure that it works with `Hash` and `Array`.

For CRuby, the approach is to never use the current State object, and always start generation with a `generate_json_data::vstate` set to `Qfalse`. It's only the first time we need to call `to_json`, that we create a temporary State which can be freely mutated by user code, since we never copy depth back from State to `generate_json_data`. All subsequent calls to `to_json` will use the same State, setting its depth to the correct value at that point.

Since State is no longer mutated, we don't need `State#generate_new` anymore.