### PR TITLE
Add a specific error for unescaped newlines

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -752,6 +752,9 @@ NOINLINE(static) VALUE json_string_unescape(JSON_ParserState *state, JSON_Parser
                 break;
             default:
                 if ((unsigned char)*pe < 0x20) {
+                    if (*pe == '\n') {
+                        raise_parse_error_at("Invalid unescaped newline character (\\n) in string: %s", state, pe - 1);
+                    }
                     raise_parse_error_at("invalid ASCII control character in string: %s", state, pe - 1);
                 }
                 raise_parse_error_at("invalid escape character in string: %s", state, pe - 1);

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -164,6 +164,14 @@ class JSONParserTest < Test::Unit::TestCase
     end
   end
 
+  def test_parse_control_chars_in_string
+    0.upto(31) do |ord|
+      assert_raise JSON::ParserError do
+        parse(%("#{ord.chr}"))
+      end
+    end
+  end
+
   def test_parse_arrays
     assert_equal([1,2,3], parse('[1,2,3]'))
     assert_equal([1.2,2,3], parse('[1.2,2,3]'))


### PR DESCRIPTION
It's the most likely control character so it's worth giving a better error message for it.