### PR TITLE
Revert "Skip test failing with JRuby in CI"

### DIFF
--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -843,7 +843,6 @@ class JSONParserTest < Test::Unit::TestCase
 
   def test_frozen
     parser_config = JSON::Parser::Config.new({}).freeze
-    omit "JRuby failure in CI" if RUBY_ENGINE == "jruby"
     assert_raise FrozenError do
       parser_config.send(:initialize, {})
     end


### PR DESCRIPTION
This reverts commit b7e1734d9ca090e95b1923b05536f5fb6f437060.

Following-up on https://github.com/ruby/json/pull/917#discussion_r2610105786.