### PR TITLE
Update `fpconv_dtoa` definition to use `dest[32]`

### DIFF
--- a/ext/json/ext/vendor/fpconv.c
+++ b/ext/json/ext/vendor/fpconv.c
@@ -449,7 +449,7 @@ static int filter_special(double fp, char* dest)
  * }
  *
  */
-static int fpconv_dtoa(double d, char dest[28])
+static int fpconv_dtoa(double d, char dest[32])
 {
     char digits[18];
 


### PR DESCRIPTION
PR #863 increased the buffer requirement to 32 bytes, but the function definition in fpconv.c was missed.

This change updates `static int fpconv_dtoa(double d, char dest[28])` to `... dest[32]` to align with the updated comments and logic.