### PR TITLE
[parser.c] Optimize unescaping unicode by directly writing to the output buffer. 

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -739,9 +739,7 @@ NOINLINE(static) VALUE json_string_unescape(JSON_ParserState *state, JSON_Parser
                     }
                 }
 
-                char buf[4];
-                int unescape_len = convert_UTF32_to_UTF8(buf, ch);
-                MEMCPY(buffer, buf, char, unescape_len);
+                int unescape_len = convert_UTF32_to_UTF8(buffer, ch);
                 buffer += unescape_len;
                 p = ++pe;
                 break;


### PR DESCRIPTION
This PR simplifies `json_string_unescape` by having `convert_UTF32_to_UTF8` write directly to the output `buffer`. This saves a `MEMCPY` as the `unescape_len` isn't known at a compile time so it isn't optimized away. At least that's what it seems based on the `samply` profile:

I'm pretty sure this doesn't introduce any potential out-of-bounds write as the current code in `master` unconditionally writes `unescape_len` bytes to `buffer` whereas this branch passes `buffer` directly to `convert_UTF32_to_UTF8` which writes the same `unescape_len` bytes to the `buffer`. 

### Before

<img width="670" height="347" alt="before" src="https://github.com/user-attachments/assets/8b0768cc-f9f4-4e24-8a0c-2dee016c5b52" />

<img width="1070" height="162" alt="image" src="https://github.com/user-attachments/assets/8000c46d-7768-4f90-bbfc-880000bcbf61" />


### After
<img width="638" height="304" alt="after" src="https://github.com/user-attachments/assets/99509bb3-9197-4fb4-bbdd-974ce4c41a35" />

<img width="1051" height="211" alt="image" src="https://github.com/user-attachments/assets/4db835fe-a179-4738-81a3-3b4c4ce1ccac" />


Benchmarking on my M1 Macbook Air shows a 2% improvement when parsing `activitypub.json` depending on run. 

```
== Parsing activitypub.json (58160 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after     1.059k i/100ms
Calculating -------------------------------------
               after     10.891k (± 1.0%) i/s   (91.82 μs/i) -     55.068k in   5.056759s

Comparison:
              before:    10694.4 i/s
               after:    10891.0 i/s - 1.02x  faster
```
