### PR TITLE
[generator.c] use a conditional to select SIMD implementation rather than pointer

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -1119,6 +1119,7 @@ static void raw_generate_json_string(FBuffer *buffer, struct generate_json_data 
     search.matches_mask = 0;
     search.has_matches = false;
     search.chunk_base = NULL;
+    search.chunk_end = NULL;
 #endif /* HAVE_SIMD */
 
     switch (rb_enc_str_coderange(obj)) {


### PR DESCRIPTION
This aligns the SIMD dispatch mechanism between the generator and the parser. The generator was implemented using function pointers to determine which `search_escape_basic*` to call. When implementing the parser, I noticed using conditionals was faster when compiling on `gcc` on `aarch64`. I never did circle back to the generator.

Run on my M1 Macbook Air - I did run these on my Macbook Pro with an M4 and saw pretty much the same increase):

```
== Encoding activitypub.json (52595 bytes)
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after     2.502k i/100ms
Calculating -------------------------------------
               after     26.433k (± 1.5%) i/s   (37.83 μs/i) -    132.606k in   5.017893s

Comparison:
              before:    24411.7 i/s
               after:    26432.6 i/s - 1.08x  faster


== Encoding citm_catalog.json (500298 bytes)
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   135.000 i/100ms
Calculating -------------------------------------
               after      1.359k (± 1.0%) i/s  (736.00 μs/i) -      6.885k in   5.067946s

Comparison:
              before:     1308.6 i/s
               after:     1358.7 i/s - 1.04x  faster


== Encoding twitter.json (466906 bytes)
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   271.000 i/100ms
Calculating -------------------------------------
               after      2.691k (± 1.4%) i/s  (371.54 μs/i) -     13.550k in   5.035448s

Comparison:
              before:     2510.1 i/s
               after:     2691.5 i/s - 1.07x  faster


== Encoding ohai.json (20145 bytes)
ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after     3.254k i/100ms
Calculating -------------------------------------
               after     32.566k (± 0.9%) i/s   (30.71 μs/i) -    165.954k in   5.096416s

Comparison:
              before:    30135.3 i/s
               after:    32565.7 i/s - 1.08x  faster
```

The performance benefit comes from (at least) inlining `search_escape_basic_neon`. There might be better code generation decisions made as a result of that inlining too. 

Interestingly `clang` did inline the code when using function pointers. 

I do realize that `clang` is the default compiler on MacOS so I would not expect this to affect too many developers on their machine. However, deploying to production using Linux will likely benefit from this as `gcc` is often (always?) the default compiler. The [offical Ruby Docker images](https://hub.docker.com/_/ruby) are built with gcc.

```
% docker run --rm ruby:4.0.1 ruby -e "puts RbConfig::CONFIG['CC']"
gcc
```

Testing this locally with an Ubuntu image:

```
== Encoding activitypub.json (52595 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [aarch64-linux]
Warming up --------------------------------------
               after     3.128k i/100ms
Calculating -------------------------------------
               after     30.957k (± 2.8%) i/s   (32.30 μs/i) -    156.400k in   5.056768s

Comparison:
              before:    28486.4 i/s
               after:    30957.4 i/s - 1.09x  faster


== Encoding citm_catalog.json (500298 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [aarch64-linux]
Warming up --------------------------------------
               after   134.000 i/100ms
Calculating -------------------------------------
               after      1.347k (± 2.2%) i/s  (742.41 μs/i) -      6.834k in   5.076657s

Comparison:
              before:     1286.0 i/s
               after:     1347.0 i/s - 1.05x  faster


== Encoding twitter.json (466906 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [aarch64-linux]
Warming up --------------------------------------
               after   298.000 i/100ms
Calculating -------------------------------------
               after      2.981k (± 0.8%) i/s  (335.45 μs/i) -     15.198k in   5.098512s

Comparison:
              before:     2766.9 i/s
               after:     2981.0 i/s - 1.08x  faster


== Encoding ohai.json (20145 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [aarch64-linux]
Warming up --------------------------------------
               after     3.398k i/100ms
Calculating -------------------------------------
               after     33.687k (± 1.7%) i/s   (29.69 μs/i) -    169.900k in   5.045015s

Comparison:
              before:    31068.4 i/s
               after:    33686.7 i/s - 1.08x  faster
```