### PR TITLE
Add SIMD support for Windows when compiled by Visual C++.

### DIFF
--- a/ext/json/ext/json.h
+++ b/ext/json/ext/json.h
@@ -94,6 +94,8 @@ typedef unsigned char _Bool;
 
 #if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ && INTPTR_MAX == INT64_MAX
 #define JSON_CPU_LITTLE_ENDIAN_64BITS 1
+#elif defined(_MSC_VER) && (defined(_M_X64) || defined(_M_AMD64))
+#define JSON_CPU_LITTLE_ENDIAN_64BITS 1
 #else
 #define JSON_CPU_LITTLE_ENDIAN_64BITS 0
 #endif


### PR DESCRIPTION
I finally figured out how to build Ruby on Windows. This allowed me to get the SSE2/SIMD code to compile using Visual C++. 

The benchmarks were run on a laptop with a `Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz (2.59 GHz)` running Windows 11 Pro.

## Generator
```
set STAGE=after & ruby -I "lib";"ext" C:/Users/smyro/Development/json/benchmark/encoder2.rb
== Encoding activitypub.json (52595 bytes)
ruby 4.1.0dev (2026-01-24T14:43:54Z master 1de6133825) +PRISM [x64-mswin64_140]
Warming up --------------------------------------
              after    825.000 i/100ms
Calculating -------------------------------------
              after       8.652k (± 2.0%) i/s  (115.58 μs/i) -     43.725k in   5.055878s

Comparison:
             before :     7174.3 i/s
              after :     8651.7 i/s - 1.21x  faster


== Encoding citm_catalog.json (500298 bytes)
ruby 4.1.0dev (2026-01-24T14:43:54Z master 1de6133825) +PRISM [x64-mswin64_140]
Warming up --------------------------------------
              after     45.000 i/100ms
Calculating -------------------------------------
              after     450.314 (± 2.9%) i/s    (2.22 ms/i) -      2.295k in   5.100855s

Comparison:
             before :      455.8 i/s
              after :      450.3 i/s - same-ish: difference falls within error


== Encoding twitter.json (466906 bytes)
ruby 4.1.0dev (2026-01-24T14:43:54Z master 1de6133825) +PRISM [x64-mswin64_140]
Warming up --------------------------------------
              after     84.000 i/100ms
Calculating -------------------------------------
              after     872.990 (± 4.9%) i/s    (1.15 ms/i) -      4.368k in   5.016760s

Comparison:
             before :      742.0 i/s
              after :      873.0 i/s - 1.18x  faster


== Encoding ohai.json (20145 bytes)
ruby 4.1.0dev (2026-01-24T14:43:54Z master 1de6133825) +PRISM [x64-mswin64_140]
Warming up --------------------------------------
              after      1.154k i/100ms
Calculating -------------------------------------
              after      11.255k (± 1.9%) i/s   (88.85 μs/i) -     56.546k in   5.025850s

Comparison:
             before :    11197.2 i/s
              after :    11255.1 i/s - same-ish: difference falls within error
```

## Parser
```
set STAGE=after & ruby -I "lib";"ext" C:/Users/smyro/Development/json/benchmark/parser2.rb
== Parsing activitypub.json (58160 bytes)
ruby 4.1.0dev (2026-01-24T14:43:54Z master 1de6133825) +PRISM [x64-mswin64_140]
Warming up --------------------------------------
              after    530.000 i/100ms
Calculating -------------------------------------
              after       5.563k (± 1.6%) i/s  (179.77 μs/i) -     28.090k in   5.051023s

Comparison:
             before :     4887.4 i/s
              after :     5562.7 i/s - 1.14x  faster


== Parsing twitter.json (567916 bytes)
ruby 4.1.0dev (2026-01-24T14:43:54Z master 1de6133825) +PRISM [x64-mswin64_140]
Warming up --------------------------------------
              after     45.000 i/100ms
Calculating -------------------------------------
              after     462.771 (± 3.2%) i/s    (2.16 ms/i) -      2.340k in   5.063128s

Comparison:
             before :      355.0 i/s
              after :      462.8 i/s - 1.30x  faster


== Parsing citm_catalog.json (1727030 bytes)
ruby 4.1.0dev (2026-01-24T14:43:54Z master 1de6133825) +PRISM [x64-mswin64_140]
Warming up --------------------------------------
              after     21.000 i/100ms
Calculating -------------------------------------
              after     217.782 (± 1.8%) i/s    (4.59 ms/i) -      1.092k in   5.016271s

Comparison:
             before :      154.9 i/s
              after :      217.8 i/s - 1.41x  faster


== Parsing ohai.json (32444 bytes)
ruby 4.1.0dev (2026-01-24T14:43:54Z master 1de6133825) +PRISM [x64-mswin64_140]
Warming up --------------------------------------
              after    475.000 i/100ms
Calculating -------------------------------------
              after       4.639k (± 2.9%) i/s  (215.55 μs/i) -     23.275k in   5.022146s

Comparison:
             before :     4209.3 i/s
              after :     4639.2 i/s - 1.10x  faster
```