### PR TITLE
Ensure `Generator::State` is kept on the stack

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+* Fix a potential crash in very specific circumstance if GC triggers during a call to `to_json`
+  without first invoking a user defined `#to_json` method.
+
 ### 2025-12-11 (2.18.0)
 
 * Add `:allow_control_characters` parser options, to allow JSON strings containing unescaped ASCII control characters (e.g. newlines).

--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -1540,7 +1540,9 @@ static VALUE cState_partial_generate(VALUE self, VALUE obj, generator_func func,
         .obj = obj,
         .func = func
     };
-    return rb_ensure(generate_json_try, (VALUE)&data, generate_json_ensure, (VALUE)&data);
+    VALUE result = rb_ensure(generate_json_try, (VALUE)&data, generate_json_ensure, (VALUE)&data);
+    RB_GC_GUARD(self);
+    return result;
 }
 
 /* call-seq:


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/929

~~I don't know how it's possible, but~~ somehow the `self` reference is optimized out of the stack. Perhaps because we inline so aggressively that the compiler end up spilling it on the heap.

Actually I get it now, the actual caller is:

```c
static VALUE mHash_to_json(int argc, VALUE *argv, VALUE self)
{
    rb_check_arity(argc, 0, 1);
    VALUE Vstate = cState_from_state_s(cState, argc == 1 ? argv[0] : Qnil);
    return cState_partial_generate(Vstate, self, generate_json_object, Qfalse);
}
```

So the GCed variable is `VState` which indeed is no longer reachable rather quickly. So the fix does checks out.

Repro:

```ruby
require 'json'

test_data = {
  "flag" => true,
  "data" => 10000.times.map { [1.0] },
  :flag => false,
}

10.times do
  test_data.to_json
end
```

But in practice the cause was just that the issued warning calls Hash#inspect on a big hash, which triggers GC.

So it can be triggered even more reliably with:

```ruby
require 'json'

module JSON
  module Common
    def self.on_mixed_keys_hash(...)
      GC.start
    end
  end
end

test_data = {
  "flag" => true,
  "data" => 10000.times.map { [1.0] },
  :flag => false,
}

test_data.to_json
```