### PR TITLE
Stop using RB_ALLOCV

### DIFF
--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -135,6 +135,10 @@ class JSONParserTest < Test::Unit::TestCase
     bignum = Integer('1234567890' * 10)
     assert_equal(bignum, JSON.parse(bignum.to_s))
     assert_equal(bignum.to_f, JSON.parse(bignum.to_s + ".0"))
+
+    bignum = Integer('1234567890' * 50)
+    assert_equal(bignum, JSON.parse(bignum.to_s))
+    assert_equal(bignum.to_f, JSON.parse(bignum.to_s + ".0"))
   end
 
   def test_parse_bigdecimals


### PR DESCRIPTION
While it's a very nice API, if the buffer is too big for the stack (> 1024B) the buffer object will be mark like a stack region which is slow and overkill for a char buffer.