### PR TITLE
Fix output formatting differences between JRuby and Ruby when converting Float to JSON

### DIFF
--- a/java/src/json/ext/Generator.java
+++ b/java/src/json/ext/Generator.java
@@ -415,12 +415,14 @@ public final class Generator {
                         return;
                     }
                 }
-                
+
                 throw Utils.buildGeneratorError(context, object, object + " not allowed in JSON").toThrowable();
             }
         }
 
-        buffer.write(Double.toString(value).getBytes(UTF_8));
+        ByteList tmp = new ByteList(24);
+        RubyFloat.formatFloat(object, tmp);
+        buffer.write(tmp.getUnsafeBytes(), tmp.getBegin(), tmp.getRealSize());
     }
 
     private static final byte[] EMPTY_ARRAY_BYTES = "[]".getBytes();

--- a/test/json/json_generator_test.rb
+++ b/test/json/json_generator_test.rb
@@ -998,12 +998,7 @@ class JSONGeneratorTest < Test::Unit::TestCase
     assert_float_roundtrip "12.0", 12.0
     assert_float_roundtrip "100.0", 100.0
     assert_float_roundtrip "1000.0", 1000.0
-
-    if RUBY_ENGINE == "jruby"
-      assert_float_roundtrip "1.7468619377842371E9", 1746861937.7842371
-    else
-      assert_float_roundtrip "1746861937.7842371", 1746861937.7842371
-    end
+    assert_float_roundtrip "1746861937.7842371", 1746861937.7842371
 
     if RUBY_ENGINE == "ruby"
       assert_float_roundtrip "100000000000000.0", 100000000000000.0


### PR DESCRIPTION
issue #817 