### PR TITLE
Use single quotes for allow_invalid_escape doc

### DIFF
--- a/lib/json.rb
+++ b/lib/json.rb
@@ -201,10 +201,10 @@ require 'json/common'
 # defaults to +false+.
 #
 # With the default, +false+:
-#   JSON.parse(%{"Hell\\o"}) # invalid escape character in string (JSON::ParserError)
+#   JSON.parse('"Hell\o"') # invalid escape character in string (JSON::ParserError)
 #
 # When enabled:
-#   JSON.parse(%{"Hell\\o"}, allow_invalid_escape: true) # => "Hello"
+#   JSON.parse('"Hell\o"', allow_invalid_escape: true) # => "Hello"
 #
 # ====== Output Options
 #


### PR DESCRIPTION
Instead of using %{} which works like double-quoted string and allows escape sequences and in which "other escaped characters (a backslash followed by a character) are interpreted as the character", change the examples for `allow_invalid_escape` to use single-quotes strings, in which "any other character following a backslash [except ' and \] is interpreted as is: a backslash and the character itself." ([Ruby doc for literals](https://docs.ruby-lang.org/en/4.0/syntax/literals_rdoc.html#label-String+Literals))

This makes it clearer the JSON document only includes a single backslash.