### PR TITLE
[C Extension] Remove unused load_uint8x16_4 function.

### DIFF
--- a/ext/json/ext/simd/simd.h
+++ b/ext/json/ext/simd/simd.h
@@ -133,16 +133,6 @@ ALWAYS_INLINE(static) int string_scan_simd_neon(const char **ptr, const char *en
     return 0;
 }
 
-static inline uint8x16x4_t load_uint8x16_4(const unsigned char *table)
-{
-    uint8x16x4_t tab;
-    tab.val[0] = vld1q_u8(table);
-    tab.val[1] = vld1q_u8(table+16);
-    tab.val[2] = vld1q_u8(table+32);
-    tab.val[3] = vld1q_u8(table+48);
-    return tab;
-}
-
 #endif /* ARM Neon Support.*/
 
 #if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64)


### PR DESCRIPTION
The `load_uint8x16_4` was originally used in the lookup table based ARM Neon implementation. That code has since been removed but this function wasn't removed. It is no longer needed. If we ever do need to load a `uint8x16x4_t` there is [vld1q_u8_x4](https://developer.arm.com/architectures/instruction-sets/intrinsics/#f:@navigationhierarchiessimdisa=[Neon]&f:@navigationhierarchiesreturnbasetype=[uint]&f:@navigationhierarchieselementbitsize=[8]&f:@navigationhierarchiesinstructiongroup=[Load]&first=20) which somehow I missed originally. It loads data sequentially instead of interleaved like `vld4q_u8`. 