### PR TITLE
Add automatic conversion to BigDecimal when using `JSON.parse` with high-precision floats

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -5,7 +5,7 @@
 static VALUE mJSON, eNestingError, Encoding_UTF_8;
 static VALUE CNaN, CInfinity, CMinusInfinity;
 
-static ID i_new, i_try_convert, i_uminus, i_encode;
+static ID i_new, i_try_convert, i_uminus, i_encode, i_BigDecimal;
 
 static VALUE sym_max_nesting, sym_allow_nan, sym_allow_trailing_comma, sym_allow_control_characters,
              sym_allow_invalid_escape, sym_symbolize_names, sym_freeze, sym_decimal_class, sym_on_load,
@@ -839,9 +839,22 @@ static inline VALUE json_decode_float(JSON_ParserConfig *config, uint64_t mantis
         return rb_funcallv(config->decimal_class, config->decimal_method_id, 1, &text);
     }
 
+    // Automatically use BigDecimal for high-precision decimals (> 17 significant digits)
+    // that would lose precision when converted to Float
+    // We check the mantissa value itself rather than the digit count to handle
+    // numbers like 0.000000022471348024634545 which have leading zeros
+    if (RB_UNLIKELY(mantissa_digits > 17 && mantissa >= 100000000000000000ULL)) {
+        if (rb_const_defined(rb_cObject, i_BigDecimal)) {
+            VALUE text = rb_str_new(start, end - start);
+            return rb_funcallv(rb_mKernel, i_BigDecimal, 1, &text);
+        }
+        // If BigDecimal is not available, fall back to regular float parsing
+        return json_decode_large_float(start, end - start);
+    }
+
     // Fall back to rb_cstr_to_dbl for potential subnormals (rare edge case)
     // Ryu has rounding issues with subnormals around 1e-310 (< 2.225e-308)
-    if (RB_UNLIKELY(mantissa_digits > 17 || mantissa_digits + exponent < -307)) {
+    if (RB_UNLIKELY(mantissa_digits + exponent < -307)) {
         return json_decode_large_float(start, end - start);
     }
 
@@ -1669,6 +1682,7 @@ void Init_parser(void)
     i_try_convert = rb_intern("try_convert");
     i_uminus = rb_intern("-@");
     i_encode = rb_intern("encode");
+    i_BigDecimal = rb_intern("BigDecimal");
 
     binary_encindex = rb_ascii8bit_encindex();
     utf8_encindex = rb_utf8_encindex();

--- a/test/json/json_addition_test.rb
+++ b/test/json/json_addition_test.rb
@@ -3,7 +3,7 @@ require_relative 'test_helper'
 require 'json/add/core'
 require 'json/add/complex'
 require 'json/add/rational'
-require 'json/add/bigdecimal'
+# require 'json/add/bigdecimal' - removed in favor of simpler BigDecimal handling
 require 'json/add/ostruct'
 require 'json/add/set'
 require 'date'
@@ -174,8 +174,14 @@ class JSONAdditionTest < Test::Unit::TestCase
   end
 
   def test_bigdecimal
-    assert_equal BigDecimal('3.141', 23), JSON(JSON(BigDecimal('3.141', 23)), :create_additions => true)
-    assert_equal BigDecimal('3.141', 666), JSON(JSON(BigDecimal('3.141', 666)), :create_additions => true)
+    # BigDecimal now serializes as plain JSON numbers, not as add/bigdecimal format
+    # Round-trip: BigDecimal -> JSON -> BigDecimal (for high-precision decimals)
+    bd = BigDecimal('3.141592653589793238462643383279502884197')
+    json = JSON(bd)
+    assert_equal('3.141592653589793238462643383279502884197', json)
+    parsed = JSON.parse(json)
+    assert_instance_of(BigDecimal, parsed)
+    assert_equal(bd, parsed)
   end if defined?(::BigDecimal)
 
   def test_ostruct

--- a/test/json/json_bigdecimal_test.rb
+++ b/test/json/json_bigdecimal_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require_relative 'test_helper'
+
+begin
+  require 'bigdecimal'
+rescue LoadError
+end
+
+class JSONBigDecimalTest < Test::Unit::TestCase
+  def test_preserves_bigdecimals_when_parsing_json_with_decimal_numbers
+    big_decimal = BigDecimal('1.12345678912345678912345')
+    json_string = '{"amount": 1.12345678912345678912345}'
+    parsed = JSON.parse(json_string)
+
+    assert_instance_of(BigDecimal, parsed['amount'])
+    assert_equal(big_decimal, parsed['amount'])
+  end if defined?(::BigDecimal)
+
+  def test_parses_string_bigdecimals_as_strings_not_bigdecimals
+    json_with_string = '{"amount": "1.12345678912345678912345"}'
+    parsed = JSON.parse(json_with_string)
+
+    # String representations should remain as strings
+    assert_instance_of(String, parsed['amount'])
+    assert_equal('1.12345678912345678912345', parsed['amount'])
+  end if defined?(::BigDecimal)
+
+  def test_handles_regular_floats_without_converting_to_bigdecimal
+    hash_with_float = { 'value' => 1.23 }
+    json_string = hash_with_float.to_json
+    parsed_back = JSON.parse(json_string)
+
+    # Regular floats should remain as floats (or be converted based on precision)
+    assert_kind_of(Numeric, parsed_back['value'])
+    assert_equal(1.23, parsed_back['value'])
+  end if defined?(::BigDecimal)
+end

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -134,11 +134,12 @@ class JSONParserTest < Test::Unit::TestCase
   def test_parse_bignum
     bignum = Integer('1234567890' * 10)
     assert_equal(bignum, JSON.parse(bignum.to_s))
-    assert_equal(bignum.to_f, JSON.parse(bignum.to_s + ".0"))
+    bignum_f = defined?(::BigDecimal) ? BigDecimal(bignum.to_s) : bignum.to_f
+    assert_equal(bignum_f, JSON.parse(bignum.to_s + ".0"))
 
     bignum = Integer('1234567890' * 50)
     assert_equal(bignum, JSON.parse(bignum.to_s))
-    bignum_float = EnvUtil.suppress_warning { bignum.to_f }
+    bignum_float = EnvUtil.suppress_warning { defined?(::BigDecimal) ? BigDecimal(bignum.to_s) : bignum.to_f }
     assert_equal(bignum_float, EnvUtil.suppress_warning { JSON.parse(bignum.to_s + ".0") })
   end
 

--- a/test/json/json_ryu_fallback_test.rb
+++ b/test/json/json_ryu_fallback_test.rb
@@ -8,29 +8,34 @@ end
 class JSONRyuFallbackTest < Test::Unit::TestCase
   include JSON
 
-  # Test that numbers with more than 17 significant digits fall back to rb_cstr_to_dbl
+  # Test that numbers with more than 17 mantissa digits are automatically converted to BigDecimal
   def test_more_than_17_significant_digits
-    # These numbers have > 17 significant digits and should use fallback path
-    # They should still parse correctly, just not via the Ryu optimization
+    # These numbers have > 17 mantissa digits and should automatically use BigDecimal
+    # to preserve precision instead of losing it to Float rounding
 
     test_cases = [
-      # input, expected (rounded to double precision)
-      ["1.23456789012345678901234567890", 1.2345678901234567],
-      ["123456789012345678.901234567890", 1.2345678901234568e+17],
-      ["0.123456789012345678901234567890", 0.12345678901234568],
-      ["9999999999999999999999999999.9", 1.0e+28],
-      # Edge case: exactly 18 digits
-      ["123456789012345678", 123456789012345680.0],
+      # input, expected BigDecimal value
+      ["1.23456789012345678901234567890", BigDecimal("1.23456789012345678901234567890")],
+      ["123456789012345678.901234567890", BigDecimal("123456789012345678.901234567890")],
+      ["0.123456789012345678901234567890", BigDecimal("0.123456789012345678901234567890")],
+      ["9999999999999999999999999999.9", BigDecimal("9999999999999999999999999999.9")],
       # Many fractional digits
-      ["0.12345678901234567890123456789", 0.12345678901234568],
+      ["0.12345678901234567890123456789", BigDecimal("0.12345678901234567890123456789")],
     ]
 
     test_cases.each do |input, expected|
       result = JSON.parse(input)
-      assert_in_delta(expected, result, 1e-10,
-        "Failed to parse #{input} correctly (>17 digits, fallback path)")
+      assert_instance_of(BigDecimal, result,
+        "Numbers with >17 mantissa digits should be parsed as BigDecimal")
+      assert_equal(expected, result,
+        "Failed to parse #{input} correctly (>17 digits, BigDecimal path)")
     end
-  end
+
+    # Integers are parsed as Integer, not BigDecimal, even if they have > 17 digits
+    result = JSON.parse("123456789012345678")
+    assert_instance_of(Integer, result)
+    assert_equal(123456789012345678, result)
+  end if defined?(::BigDecimal)
 
   # Test decimal_class option forces fallback
   def test_decimal_class_option
@@ -68,19 +73,27 @@ class JSONRyuFallbackTest < Test::Unit::TestCase
     end
   end
 
-  # Test edge cases at the boundary (17 digits)
+  # Test edge cases at the boundary (17 mantissa digits)
   def test_seventeen_digit_boundary
-    # Exactly 17 significant digits should use Ryu
-    input_17 = "12345678901234567.0"  # Force it to be a float with .0
-    result = JSON.parse(input_17)
-    assert_in_delta(12345678901234567.0, result, 1e-10)
+    # Exactly 17 mantissa digits should use Ryu and return Float
+    # Note: "12345678901234567" is exactly 17 digits as an integer
+    input_17_int = "12345678901234567"
+    result_int = JSON.parse(input_17_int)
+    assert_instance_of(Integer, result_int)
+    assert_equal(12345678901234567, result_int)
 
-    # 18 significant digits should use fallback
-    input_18 = "123456789012345678.0"
+    # Exactly 17 mantissa digits with decimal should use Ryu and return Float
+    input_17 = "1.2345678901234567"  # 17 mantissa digits
+    result = JSON.parse(input_17)
+    assert_instance_of(Float, result)
+    assert_in_delta(1.2345678901234567, result, 1e-16)
+
+    # 18 mantissa digits should automatically use BigDecimal
+    input_18 = "1.23456789012345678"  # 18 mantissa digits
     result = JSON.parse(input_18)
-    # Note: This will be rounded to double precision
-    assert_in_delta(123456789012345680.0, result, 1e-10)
-  end
+    assert_instance_of(BigDecimal, result) if defined?(::BigDecimal)
+    assert_equal(BigDecimal("1.23456789012345678"), result)
+  end if defined?(::BigDecimal)
 
   # Test that leading zeros don't count toward the 17-digit limit
   def test_leading_zeros_dont_count


### PR DESCRIPTION
Automatically parses JSON numbers with >17 significant digits as BigDecimal, falls back to using Float otherwise. This behaviour is conditional on "bigdecimal" being around, and will fall back on current behaviour of converting to Float with precision loss otherwise.

This behaviour matches what `Oj.load` does [by default](https://github.com/ohler55/oj/blob/develop/lib/oj/mimic.rb#L19-L20), and is a proposal designed to smoothen migrations away from `oj`. 

@byroot while I started #944 mostly focused on encoding bigdecimals, which we agreed it could be done via some monkeypatching which eventually can live in activesupport, the main blocker for our internal migration has actually been parsing. I mentioned that, by using `JSON.load` with `:decimal_class` option, but in practice this is turning out not to be true, for a few reasons.

The main one is that `JSON.load` and `JSON.parse` have some surprisingly different behaviour. Take these examples:

```ruby
# JSON.load is liberal with empty string
JSON.load("") #=> nil
JSON.parse("") #=> unexpected end of input at line 1 column 1 (JSON::ParserError)

# JSON.load ignores inputs which can't be converted
JSON.load([]) #=> nil
JSON.parse([]) #=> no implicit conversion of Array into String (TypeError)
# sidenote, but the above is made even more confusing with oj's monkey-patching of JSON.load and JSON.parse...
JSON.load([]) #=> ArgumentError: parser io argument must be a String or respond to readpartial() or read(). (ArgumentError)
JSON.parse([]) #=> []
```

The difference in behaviour and the (in our case) widespread use of `JSON.parse` (partly driven by a rubocop cop which prevents usage of `JSON.load` for security reasons) make a rewrite to `JSON.load` quite risky. 

Another drawback is that 3rd party libs mostly use `JSON.parse` under the hood, and few/none allow passing down your own json decoder, so one could convert everything to `JSON.load` potentially and still trip on it down the line.

A way to use `JSON.parse` while supporting this conversion to bigdecimals would be ideal. `json` does not support a similar `:bigdecimal_load` option, and `JSON.parse` does not support global options anyway (not that I'm advocating for it), hence why I went with this "no config" approach based on having bigdecimals loaded. 

There's also the argument of backwards compatibility (a bigdecimal is not a float) which could surprise someone in case of a release. I'm not sure what's the best way to deal with this, but FWIW I still consider that the benefit (no precision loss) would outweight the backwards incompatible change cost. 

This change was originally authored by @samgiddins while trying to solve the same issue internally. FYI I removed everything encoding-related, removed the block always trying to load bigdecimal, and tweaked the check for const defined.