### PR TITLE
Fix `allow_blank` parsing option to only consider strings.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+* Fix `allow_blank` parsing option to no longer allow invalid types (e.g. `load([], allow_blank: true)` now raise a type error).
 * Add `allow_invalid_escape` parsing option to ignore backslashes that aren't followed by one of the valid escape characters.
 
 ### 2026-02-03 (2.18.1)

--- a/lib/json/common.rb
+++ b/lib/json/common.rb
@@ -880,7 +880,7 @@ module JSON
       end
     end
 
-    if opts[:allow_blank] && (source.nil? || source.empty?)
+    if opts[:allow_blank] && (source.nil? || (String === source && source.empty?))
       source = 'null'
     end
 

--- a/test/json/json_common_interface_test.rb
+++ b/test/json/json_common_interface_test.rb
@@ -150,6 +150,8 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
     assert_equal nil, JSON.load(nil, nil, :allow_blank => true)
     assert_raise(TypeError) { JSON.load(nil, nil, :allow_blank => false) }
     assert_raise(JSON::ParserError) { JSON.load('', nil, :allow_blank => false) }
+    assert_raise(TypeError) { JSON.load([], nil, :allow_blank => true) }
+    assert_raise(TypeError) { JSON.load({}, nil, :allow_blank => true) }
   end
 
   def test_unsafe_load


### PR DESCRIPTION
Ref: https://github.com/ruby/json/pull/946