### PR TITLE
Reduce warnings

### DIFF
--- a/test/json/json_ryu_fallback_test.rb
+++ b/test/json/json_ryu_fallback_test.rb
@@ -174,10 +174,10 @@ class JSONRyuFallbackTest < Test::Unit::TestCase
     assert_equal Float::INFINITY, JSON.parse("1e4294967295")
     assert_equal Float::INFINITY, JSON.parse("1e4294967297")
 
-    assert_equal -Float::INFINITY, JSON.parse("-1e4294967296")
-    assert_equal -0.0, JSON.parse("-1e-4294967296")
-    assert_equal -0.0, JSON.parse("-99999999999999999e-4294967296")
-    assert_equal -Float::INFINITY, JSON.parse("-1e4294967295")
-    assert_equal -Float::INFINITY, JSON.parse("-1e4294967297")
+    assert_equal(-Float::INFINITY, JSON.parse("-1e4294967296"))
+    assert_equal(-0.0, JSON.parse("-1e-4294967296"))
+    assert_equal(-0.0, JSON.parse("-99999999999999999e-4294967296"))
+    assert_equal(-Float::INFINITY, JSON.parse("-1e4294967295"))
+    assert_equal(-Float::INFINITY, JSON.parse("-1e4294967297"))
   end
 end


### PR DESCRIPTION
```
../test/json/json_ryu_fallback_test.rb:177: warning: ambiguous first argument; put parentheses or a space even after `-` operator
../test/json/json_ryu_fallback_test.rb:178: warning: ambiguous first argument; put parentheses or a space even after `-` operator
../test/json/json_ryu_fallback_test.rb:179: warning: ambiguous first argument; put parentheses or a space even after `-` operator
../test/json/json_ryu_fallback_test.rb:180: warning: ambiguous first argument; put parentheses or a space even after `-` operator
../test/json/json_ryu_fallback_test.rb:181: warning: ambiguous first argument; put parentheses or a space even after `-` operator
```
