### PR TITLE
Fix references to NAN and INFINITY in documentation

### DIFF
--- a/lib/json.rb
+++ b/lib/json.rb
@@ -335,8 +335,8 @@ require 'json/common'
 #   JSON.generate(JSON::MinusInfinity)
 #
 # Allow:
-#   ruby = [Float::NaN, Float::Infinity, Float::MinusInfinity]
-#   JSON.generate(ruby, allow_nan: true) # => '[NaN,Infinity,-Infinity]'
+#   ruby = [Float::NAN, Float::INFINITY, JSON::NaN, JSON::Infinity, JSON::MinusInfinity]
+#   JSON.generate(ruby, allow_nan: true) # => '[NaN,Infinity,NaN,Infinity,-Infinity]'
 #
 # ---
 #


### PR DESCRIPTION
Fixes typos in the [documentation](https://docs.ruby-lang.org/en/3.4/JSON.html#module-JSON-label-Generating+Options) for `Float::INFINITY` and `Float::NAN` to make the example code work.

This gem [redefines](https://github.com/ruby/json/blob/18d54757d38fce2eea6cb821458b1df4405a256e/lib/json/common.rb#L242) `Float::NAN` as `JSON::NaN` and `Float::INFINITY` as `JSON::Infinity`, so the docs use the wrong casing. 

I added both the `Float::` and `JSON::` variations to make it more clear.

Tested in `irb` on Ruby 3.4.0:

```ruby
irb(main):001> JSON.generate([Float::NAN, Float::INFINITY, JSON::NaN, JSON::Infinity, JSON::MinusInfinity], allow_nan: true)
=> "[NaN,Infinity,NaN,Infinity,-Infinity]"

irb(main):002> JSON.generate([Float::Infinity], allow_nan: true)
(irb):2:in '<main>': uninitialized constant Float::Infinity (NameError)

irb(main):003> JSON.generate([Float::NaN], allow_nan: true)
(irb):3:in '<main>': uninitialized constant Float::NaN (NameError)
```