### PR TITLE
[generator.c] Use RB_ENC_CODERANGE to check the cached coderange before calling rb_enc_str_coderange

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -819,9 +819,17 @@ static VALUE encode_json_string_rescue(VALUE str, VALUE exception)
     return Qundef;
 }
 
+static inline int json_str_coderange(VALUE str) {
+    int coderange = RB_ENC_CODERANGE(str);
+    if (coderange == RUBY_ENC_CODERANGE_UNKNOWN) {
+        coderange = rb_enc_str_coderange(str);
+    }
+    return coderange;
+}
+
 static inline bool valid_json_string_p(VALUE str)
 {
-    int coderange = rb_enc_str_coderange(str);
+    int coderange = json_str_coderange(str);
 
     if (RB_LIKELY(coderange == ENC_CODERANGE_7BIT)) {
         return true;
@@ -893,7 +901,7 @@ static void raw_generate_json_string(FBuffer *buffer, struct generate_json_data 
     search.chunk_end = NULL;
 #endif /* HAVE_SIMD */
 
-    switch (rb_enc_str_coderange(obj)) {
+    switch (json_str_coderange(obj)) {
         case ENC_CODERANGE_7BIT:
         case ENC_CODERANGE_VALID:
             if (RB_UNLIKELY(data->state->ascii_only)) {


### PR DESCRIPTION
This PR introduces a function `json_str_coderange` to first check the cached coderange via `RB_ENC_CODERANGE` before calling `rb_enc_str_coderange`.

As per the `samply` profiler when profiling `activitypub.json`, we can see we're spending 3.1% of the time in `rb_enc_str_coderange`.

<img width="440" height="71" alt="image" src="https://github.com/user-attachments/assets/3601f89b-fdd5-43ee-a32f-291cb6c9635f" />

The code is spending almost all of the time in the early exit path + returning to the caller:

<img width="387" height="120" alt="image" src="https://github.com/user-attachments/assets/4d719201-85ed-44ec-ab2a-e23e67df324a" />

It could be possible this is just an artifact of the benchmark. We load the `activitypub.json` once, then constantly generate JSON. After the first scan, every string should have it's coderange known. I'm not sure if this holds in general though.

I did find pretty much the same code in [re.c - str_coderange](https://github.com/ruby/ruby/blob/master/re.c#L1587-L1595).

## Benchmarks

Benchmarks run on an M1 Macbook Air.

```
== Encoding activitypub.json (52595 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after     2.840k i/100ms
Calculating -------------------------------------
               after     28.777k (± 1.7%) i/s   (34.75 μs/i) -    144.840k in   5.034576s

Comparison:
              before:    27075.2 i/s
               after:    28777.2 i/s - 1.06x  faster


== Encoding citm_catalog.json (500298 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   141.000 i/100ms
Calculating -------------------------------------
               after      1.419k (± 1.1%) i/s  (704.61 μs/i) -      7.191k in   5.067439s

Comparison:
              before:     1360.1 i/s
               after:     1419.2 i/s - 1.04x  faster


== Encoding twitter.json (466906 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   299.000 i/100ms
Calculating -------------------------------------
               after      2.954k (± 1.3%) i/s  (338.51 μs/i) -     14.950k in   5.061485s

Comparison:
              before:     2780.3 i/s
               after:     2954.2 i/s - 1.06x  faster


== Encoding ohai.json (20145 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after     3.783k i/100ms
Calculating -------------------------------------
               after     37.564k (± 3.7%) i/s   (26.62 μs/i) -    189.150k in   5.044004s

Comparison:
              before:    34472.6 i/s
               after:    37564.0 i/s - 1.09x  faster
```