### PR TITLE
[generator.c] Mark `ensure_valid_encoding` as ALWAYS_INLINE.

### DIFF
--- a/ext/json/ext/generator/generator.c
+++ b/ext/json/ext/generator/generator.c
@@ -842,12 +842,8 @@ static inline bool valid_json_string_p(VALUE str)
     return false;
 }
 
-static inline VALUE ensure_valid_encoding(struct generate_json_data *data, VALUE str, bool as_json_called, bool is_key)
+NOINLINE(static) VALUE convert_invalid_encoding(struct generate_json_data *data, VALUE str, bool as_json_called, bool is_key)
 {
-    if (RB_LIKELY(valid_json_string_p(str))) {
-        return str;
-    }
-
     if (!as_json_called && data->state->strict && RTEST(data->state->as_json)) {
         VALUE coerced_str = json_call_as_json(data->state, str, Qfalse);
         if (coerced_str != str) {
@@ -881,6 +877,16 @@ static inline VALUE ensure_valid_encoding(struct generate_json_data *data, VALUE
     }
 
     return rb_rescue(encode_json_string_try, str, encode_json_string_rescue, str);
+}
+
+ALWAYS_INLINE(static) VALUE ensure_valid_encoding(struct generate_json_data *data, VALUE str, bool as_json_called, bool is_key)
+{
+    if (RB_LIKELY(valid_json_string_p(str))) {
+        return str;
+    }
+    else {
+        return convert_invalid_encoding(data, str, as_json_called, is_key);
+    }
 }
 
 static void raw_generate_json_string(FBuffer *buffer, struct generate_json_data *data, VALUE obj)


### PR DESCRIPTION
This PR forces `ensure_valid_encoding` to be inlined. 

Saving the functional call overhead seems to provide a decent speedup in some of the realworld benchmarks.

## Benchmarks

Benchmarks run on an M1 Macbook Air.

Compiled with:

```
 % cc -v
Apple clang version 17.0.0 (clang-1700.0.13.3)
Target: arm64-apple-darwin24.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

```
== Encoding activitypub.json (52595 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after     2.894k i/100ms
Calculating -------------------------------------
               after     30.089k (± 2.0%) i/s   (33.24 μs/i) -    150.488k in   5.003480s

Comparison:
              before:    29256.1 i/s
               after:    30088.5 i/s - same-ish: difference falls within error


== Encoding citm_catalog.json (500298 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   150.000 i/100ms
Calculating -------------------------------------
               after      1.494k (± 1.0%) i/s  (669.39 μs/i) -      7.500k in   5.020958s

Comparison:
              before:     1424.5 i/s
               after:     1493.9 i/s - 1.05x  faster


== Encoding twitter.json (466906 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   314.000 i/100ms
Calculating -------------------------------------
               after      3.153k (± 1.6%) i/s  (317.16 μs/i) -     16.014k in   5.080214s

Comparison:
              before:     3027.7 i/s
               after:     3153.0 i/s - 1.04x  faster


== Encoding ohai.json (20145 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after     3.976k i/100ms
Calculating -------------------------------------
               after     39.558k (± 1.4%) i/s   (25.28 μs/i) -    198.800k in   5.026466s

Comparison:
              before:    38107.3 i/s
               after:    39558.4 i/s - 1.04x  faster
```