### PR TITLE
ResumableParser#partial_value avoid mutating the stacks

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -2496,6 +2496,9 @@ static VALUE cResumableParser_partial_value(VALUE self)
     JSON_ResumableParser *original_parser = ResumableParser_acquire(self, false);
     JSON_ResumableParser parser = *original_parser;
 
+    parser.state.frames = &parser.frames;
+    parser.state.value_stack = &parser.value_stack;
+
     if (parser.value_stack.head == 0) {
         return Qnil;
     }

--- a/test/json/resumable_parser_test.rb
+++ b/test/json/resumable_parser_test.rb
@@ -156,6 +156,20 @@ class JSONResumageParserTest < Test::Unit::TestCase
     assert_partial_value([1, { "a" => 1, "b" => { "c" => nil } }], '[1, { "a": 1, "b": { "c"')
   end
 
+  def test_partial_value_issue_1005
+    data = <<~JSON
+      [
+      []
+      ]
+    JSON
+    data.each_line do |line|
+      @parser << line
+      @parser.parse
+      @parser.partial_value # This unexpected parse error doesn't happen if we comment this out
+    end
+    assert_equal [[]], @parser.value
+  end
+
   def test_partial_value_missing
     assert_nil @parser.partial_value
   end


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/1005

`parser.state.frames` and `parser.state.value_stack` need to be updated to point to the copy.