### PR TITLE
ResumableParser: Reset err_info on EOS errors

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -2412,6 +2412,7 @@ static VALUE cResumableParser_parse(VALUE self)
         complete = false;
         if (RTEST(rb_ivar_get(rb_errinfo(), rb_intern("@eos")))) {
             complete = false; // is an EOS error
+            rb_set_errinfo(Qnil);
         } else {
             rb_jump_tag(status); // reraise
         }


### PR DESCRIPTION
Fix: https://github.com/ruby/json/issues/1008

I'm unfortunately unable to turn the reproduction script into a test case there, I don't understand what is causing `err_info` to be re-raised in the repro that doesn't work in test-unit.

```ruby
require 'json'
parser = JSON::ResumableParser.new({})
['{"message": "hello ', 'world"}', '[1,2]'].each do |chunk|
  parser << chunk
  begin
    while parser.parse
      p parser.value
    end
  rescue JSON::ParserError => e
    p e
    parser.clear
  end
end
```