### PR TITLE
Is it intentional that `#partial_value` calls `on_load`?

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -2481,18 +2481,9 @@ static VALUE cResumableParser_clear(VALUE self)
     return self;
 }
 
-/*
- * call-seq: partial_value -> object
- *
- * Returns the Ruby objects parsed up to this point:
- *   parser << '[1, [2, 3,'
- *   parser.parse # => false
- *   parser.value # ArgumentError no ready value
- *   parser.partial_value # => [1, [2, 3]]
- */
-static VALUE cResumableParser_partial_value(VALUE self)
+static VALUE cResumableParser_partial_value_body(VALUE self)
 {
-    JSON_ResumableParser *original_parser = ResumableParser_acquire(self, false);
+    JSON_ResumableParser *original_parser = cResumableParser_get(self);
     JSON_ResumableParser parser = *original_parser;
 
     parser.state.frames = &parser.frames;
@@ -2557,6 +2548,28 @@ static VALUE cResumableParser_partial_value(VALUE self)
 
     ALLOCV_END(tmpbuf);
     return partial_result;
+}
+
+/*
+ * call-seq: partial_value -> object
+ *
+ * Returns the Ruby objects parsed up to this point:
+ *   parser << '[1, [2, 3,'
+ *   parser.parse # => false
+ *   parser.value # ArgumentError no ready value
+ *   parser.partial_value # => [1, [2, 3]]
+ */
+static VALUE cResumableParser_partial_value(VALUE self)
+{
+    JSON_ResumableParser *parser = ResumableParser_acquire(self, true);
+
+    int status;
+    VALUE result = rb_protect(cResumableParser_partial_value_body, self, &status);
+    parser->in_use = false;
+    if (status) {
+        rb_jump_tag(status);
+    }
+    return result;
 }
 
 /*

--- a/test/json/resumable_parser_test.rb
+++ b/test/json/resumable_parser_test.rb
@@ -208,6 +208,26 @@ class JSONResumageParserTest < Test::Unit::TestCase
     assert_equal "ResumableParser can't be used recursively", error.message
   end
 
+  def test_reentrency_prevented_in_partial_value
+    parser = nil
+    callback = ->(o) do
+      # Arrays are only built while partial_value runs (the scalars were pushed by the
+      # earlier parse); re-entering here used to corrupt/free the shared frame stack.
+      parser.parse if o.is_a?(Array)
+      o
+    end
+    parser = new_parser(on_load: callback)
+    parser << '[1, [2, 3,'
+    parser.parse
+    error = assert_raise ArgumentError do
+      parser.partial_value
+    end
+    assert_equal "ResumableParser can't be used recursively", error.message
+
+    # The in_use lock must be released even though partial_value raised.
+    refute_predicate parser, :value?
+  end
+
   def test_exception_unlock_parser
     called = false
     parser = nil


### PR DESCRIPTION
Currently `#partial_value` sometimes calls `on_load`. Is this intentional?

If it is, the `in_use` lock has to cover `#partial_value` too: otherwise touching the parser from within `on_load` triggers a use-after-free.  
```ruby
require "json"
parser = nil
parser = JSON::ResumableParser.new(on_load: ->(o) {
  parser.parse if o.is_a?(Array) # re-entrant
  o
})
parser << "[1,"
parser.parse
parser.partial_value # AddressSanitizer: heap-use-after-free
```

The fix in this PR holds `in_use` for the duration of `#partial_value`, like `#parse` does.

Personally, `#partial_value` is interesting, but I am not sure it has a real use case.