### PR TITLE
Fix `JSON::ResumableParser#parse` leaking the `in_use` lock on an empty buffer

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -2377,6 +2377,7 @@ static VALUE cResumableParser_parse(VALUE self)
 {
     JSON_ResumableParser *parser = ResumableParser_acquire(self, true);
     if (!parser->buffer) {
+        parser->in_use = false;
         return Qfalse;
     }
 

--- a/test/json/resumable_parser_test.rb
+++ b/test/json/resumable_parser_test.rb
@@ -48,6 +48,21 @@ class JSONResumageParserTest < Test::Unit::TestCase
     refute_predicate @parser, :value?
   end
 
+  def test_parse_with_empty_buffer_keeps_parser_usable
+    # parse before any feed must not leak the in_use lock
+    refute @parser.parse
+    @parser << '[1, 2, 3]'
+    assert @parser.parse
+    assert_equal [1, 2, 3], @parser.value
+
+    # same after a clear with no following feed
+    @parser.clear
+    refute @parser.parse
+    @parser << '[4]'
+    assert @parser.parse
+    assert_equal [4], @parser.value
+  end
+
   def test_parse_document_direct
     @parser << '[true]'
     assert_equal true, @parser.parse


### PR DESCRIPTION
`#parse` sets `in_use` then returns early on an empty buffer without clearing it, permanently bricking the parser.

```ruby
require "json"
parser = JSON::ResumableParser.new
parser.parse          # => false, but leaks in_use = true
parser << "[1,2,3]"
parser.parse          # ArgumentError: ResumableParser can't be used recursively
```