### PR TITLE
Reset all per-parse state in `JSON::ResumableParser#clear`

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -2487,6 +2487,9 @@ static VALUE cResumableParser_clear(VALUE self)
     parser->frames.head = 0;
     parser->value_stack.head = 0;
     parser->state.name_cache.length = 0;
+    parser->state.current_nesting = 0;
+    parser->state.in_array = 1;
+    parser->state.emitted_deprecations = 0;
     parser->state.start = parser->state.cursor = parser->state.end = NULL;
     return self;
 }

--- a/test/json/resumable_parser_test.rb
+++ b/test/json/resumable_parser_test.rb
@@ -63,6 +63,20 @@ class JSONResumageParserTest < Test::Unit::TestCase
     assert_equal [4], @parser.value
   end
 
+  def test_clear_resets_nesting_depth
+    # An unfinished document leaks a nesting level; #clear must reset it so a later shallow
+    # document is not rejected with a spurious NestingError.
+    parser = new_parser(max_nesting: 10)
+    10.times do
+      parser << '[1' # opens an array that is never closed before clear
+      parser.parse
+      parser.clear
+    end
+    parser << '[1]'
+    assert parser.parse
+    assert_equal [1], parser.value
+  end
+
   def test_parse_document_direct
     @parser << '[true]'
     assert_equal true, @parser.parse


### PR DESCRIPTION
Currently, `#clear` does not reset `current_nesting`.

```ruby
require "json"
parser = JSON::ResumableParser.new(max_nesting: 10)
10.times do
  parser << "[1"
  parser.parse
  parser.clear
end
parser << "[1"
parser.parse   # JSON::NestingError: nesting of 11 is too deep
```

This PR resets `current_nesting`.
                                                                                                                                               It also resets `in_array` and `emitted_deprecations` just for case, though I am not sure whether we should reset `emitted_deprecations` or not.