### PR TITLE
Fix off-by-one line number in parse error messages

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -593,6 +593,7 @@ static void cursor_position(JSON_ParserState *state, long *line_out, long *colum
 
     while (cursor >= state->start) {
         if (*cursor-- == '\n') {
+            line++;
             break;
         }
         column++;

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -862,7 +862,7 @@ class JSONParserTest < Test::Unit::TestCase
   end
 
   def test_parse_error_snippet
-    omit "C ext only test" unless RUBY_ENGINE == "ruby"
+    omit "JRuby errors don't contain positions" unless RUBY_ENGINE == "ruby"
 
     error = assert_raise(JSON::ParserError) { JSON.parse("あああああああああああああああああああああああ") }
     assert_equal "unexpected character: 'ああああああああああ' at line 1 column 1", error.message
@@ -875,6 +875,15 @@ class JSONParserTest < Test::Unit::TestCase
 
     error = assert_raise(JSON::ParserError) { JSON.parse("abcあああああああああああああああああああああああ") }
     assert_equal "unexpected character: 'abcあああああああああ' at line 1 column 1", error.message
+
+    error = assert_raise(JSON::ParserError) { JSON.parse("[1,\n@") }
+    assert_equal "unexpected character: '@' at line 2 column 1", error.message
+
+    error = assert_raise(JSON::ParserError) { JSON.parse("[\n  1,\n  @\n]") }
+    assert_equal "unexpected character: '@' at line 3 column 3", error.message
+
+    error = assert_raise(JSON::ParserError) { JSON.parse("@") }
+    assert_equal "unexpected character: '@' at line 1 column 1", error.message
   end
 
   def test_parse_leading_slash


### PR DESCRIPTION
Parse error messages report the line number one too low whenever the error is past the first line.

```ruby
require "json"
JSON.parse("[1,\n@")
# expected: unexpected character: '@' at line 2 column 1
# actual:   unexpected character: '@' at line 1 column 1
```