### PR TITLE
Document that `JSON::ResumableParser` does not bound its buffer size

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -2261,6 +2261,11 @@ static inline JSON_ResumableParser *cResumableParser_get(VALUE self)
  *   parser << ' '
  *   parser.parse # => true
  *   parser.value # => 123
+ *
+ * === Security
+ *
+ * An incomplete document is buffered in full and there is no size limit, so when reading
+ * from an untrusted source the caller is responsible for bounding how much data is fed.
  */
 static VALUE cResumableParser_initialize(int argc, VALUE *argv, VALUE self)
 {


### PR DESCRIPTION
`JSON::ResumableParser` buffers the input until a document completes, so careless use can lead to a DoS.

```ruby
require "json"
parser = JSON::ResumableParser.new
parser << '"'                  # start a string, never close it
parser << "a" * 5_000_000      # the whole unterminated string is buffered
parser.parse                   # => false (nothing consumed or released)
parser.rest.bytesize           # => 5000001 (keeps growing; OOM if you keep feeding)
```

This PR documents in the rdoc that bounding the input is the caller's responsibility.

Maybe an option like `ResumableParser.new(buffer_size_limit: 1024)` would also be worth having?