### PR TITLE
Read ASCII-incompatible strings in binary mode

### DIFF
--- a/test/json/json_minefield_parser_test.rb
+++ b/test/json/json_minefield_parser_test.rb
@@ -78,7 +78,7 @@ class JSONMinefieldParserTest < Test::Unit::TestCase
   end
 
   fixtures.each do |path|
-    payload = File.read(path)
+    payload = File.binread(path)
     name = File.basename(path, '.json')
 
     if COMMENT_TESTS.include?(name)


### PR DESCRIPTION
> Lots of encoding errors.
> http://rubyci.s3.amazonaws.com/debian/ruby-master/log/20260618T093002Z.fail.html.gz
> 
> Probably need to read in binary mode:
> ```suggestion
>     payload = File.binread(path)
> ``` 

 _Originally posted by @nobu in [#1015](https://github.com/ruby/json/pull/1015/changes#r3439759830)_