### PR TITLE
Avoid Float out of range warning for clearly underflowing numbers

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -1133,6 +1133,13 @@ static inline VALUE json_decode_float(JSON_ParserConfig *config, uint64_t mantis
     }
 
     if (RB_UNLIKELY(mantissa_digits > 18 || mantissa_digits + exponent < -307)) {
+        // If the value is so small that it definitely underflows to 0.0, return early
+        // to avoid triggering a "Float out of range" warning from rb_cstr_to_dbl.
+        // When mantissa_digits + exponent < -324, value < 10^(-324) < DBL_TRUE_MIN/2,
+        // so it rounds to 0 in IEEE 754 round-to-nearest.
+        if (RB_UNLIKELY(mantissa_digits + exponent < -324)) {
+            return rb_float_new(negative ? -0.0 : 0.0);
+        }
         return json_decode_large_float(start, end - start);
     }
 


### PR DESCRIPTION
Two new minefield parser tests (`test_i_number_double_huge_neg_exp`, `test_i_number_real_underflow`) introduced in 6507a836c5 cause spurious CI warnings because numbers like `123.456e-789` and `123e-10000000` fall through to `json_decode_large_float` → `rb_cstr_to_dbl` → `strtod`, which sets `errno=ERANGE` on underflow and triggers Ruby's `rb_warning("Float %s out of range", ...)`.

## Fix

Add an early-return guard in `json_decode_float()` before the `rb_cstr_to_dbl` fallback:

```c
if (RB_UNLIKELY(mantissa_digits > 18 || mantissa_digits + exponent < -307)) {
    if (RB_UNLIKELY(mantissa_digits + exponent < -324)) {
        return rb_float_new(negative ? -0.0 : 0.0);
    }
    return json_decode_large_float(start, end - start);
}
```

When `mantissa_digits + exponent < -324`, the value is bounded above by `10^(-324) = 1e-324 < DBL_TRUE_MIN/2 ≈ 2.47e-324`, so IEEE 754 round-to-nearest guarantees a result of `0.0` — no need to call `rb_cstr_to_dbl`. The subnormal range (`-324 ≤ mantissa_digits + exponent < -307`) still goes through `rb_cstr_to_dbl` for accurate results.

Same approach as 5b4d95b8d0 which added the `exponent < INT32_MIN → 0.0` fast-path with the same motivation.
