### PR TITLE
[parser.c] Widen the json_decode_integer fast path to more 64-bit integers.

### DIFF
--- a/ext/json/ext/parser/parser.c
+++ b/ext/json/ext/parser/parser.c
@@ -1082,7 +1082,8 @@ NOINLINE(static) VALUE json_string_unescape(JSON_ParserState *state, JSON_Parser
     return result;
 }
 
-#define MAX_FAST_INTEGER_SIZE 18
+#define MAX_FAST_INTEGER_SIZE 19
+#define MAX_FAST_UINT64_SIZE  20
 #define MAX_NUMBER_STACK_BUFFER 128
 
 typedef VALUE (*json_number_decode_func_t)(const char *ptr);
@@ -1117,11 +1118,30 @@ NOINLINE(static) VALUE json_decode_large_integer(const char *start, long len)
 
 static inline VALUE json_decode_integer(uint64_t mantissa, int mantissa_digits, bool negative, const char *start, const char *end)
 {
-    if (RB_LIKELY(mantissa_digits < MAX_FAST_INTEGER_SIZE)) {
-        if (negative) {
+    if (RB_LIKELY(mantissa_digits <= MAX_FAST_INTEGER_SIZE)) {
+        if (RB_LIKELY(!negative)) {
+            return UINT64T2NUM(mantissa);
+        }
+
+        // For a negative number 19 digits in length, we only get half of the range,
+        // so ensure this negative number is less than INT64_MAX. 
+        //
+        // Note: This does miss INT64_MIN as it's value is one past INT64_MAX
+        // when converted to a uint64_t. It will still be parsed correctly by 
+        // falling through to json_decode_large_integer.
+        if (RB_LIKELY(mantissa <= (uint64_t)INT64_MAX)) {
             return INT64T2NUM(-((int64_t)mantissa));
         }
-        return UINT64T2NUM(mantissa);
+    }
+
+    if (!negative && mantissa_digits == MAX_FAST_UINT64_SIZE) {
+        // Not all 20 digit integers can be safely represented by a uint64_t but
+        // some can. The memcmp with uint64_max is safe as we've rejected leading
+        // zeros and we have guaranteed we're comparing it with a 20 digit number.
+        static const char uint64_max[] = "18446744073709551615";
+        if (memcmp(end - MAX_FAST_UINT64_SIZE, uint64_max, MAX_FAST_UINT64_SIZE) <= 0) {
+            return UINT64T2NUM(mantissa);
+        }
     }
 
     return json_decode_large_integer(start, end - start);

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -132,6 +132,37 @@ class JSONParserTest < Test::Unit::TestCase
     capture_output { assert_equal(Float::INFINITY, parse("23456789012E666")) }
   end
 
+  INTEGER_FAST_PATH_BOUNDARIES = [
+    "999999999999999999",    # 18 digits
+    "1000000000000000000",   # narrowest 19 digits
+    "9999999999999999999",   # widest 19 digits, still inside uint64_t
+    "-999999999999999999",
+    "-9223372036854775807",  # INT64_MAX, the widest negatable accumulator
+    "-9223372036854775808",  # INT64_MIN, one past what negating a uint64_t covers
+    "-9223372036854775809",
+    "-9999999999999999999",  # widest negative 19 digits
+    "10000000000000000000",  # narrowest 20 digits
+    "18446744073709551614",
+    "18446744073709551615",  # UINT64_MAX exactly, the last value the range check admits
+    "18446744073709551616",  # 2**64, first value it must reject
+    "18446744073709551617",
+    "19999999999999999999",
+    "99999999999999999999",  # widest 20 digits
+    "-18446744073709551615", # negatives never take the 20 digit path
+    "-18446744073709551616",
+    "-99999999999999999999",
+    "100000000000000000000", # 21 digits, always a bignum
+    "-100000000000000000000",
+  ].freeze
+
+  def test_parse_integer_boundaries
+    INTEGER_FAST_PATH_BOUNDARIES.each do |literal|
+      expected = Integer(literal, 10)
+
+      assert_equal(expected, parse(literal))
+    end
+  end
+
   def test_parse_bignum
     bignum = Integer('1234567890' * 10)
     assert_equal(bignum, JSON.parse(bignum.to_s))

--- a/test/json/resumable_parser_test.rb
+++ b/test/json/resumable_parser_test.rb
@@ -192,6 +192,27 @@ class JSONResumageParserTest < Test::Unit::TestCase
     end
   end
 
+  def test_integer_boundaries_split_across_feeds
+    [
+      '9999999999999999999',   # widest 19 digits
+      '-9223372036854775808',  # INT64_MIN
+      '18446744073709551615',  # UINT64_MAX exactly
+      '18446744073709551616',  # 2**64, wraps the accumulator to 0
+      '99999999999999999999',  # widest 20 digits
+      '-18446744073709551616',
+      '100000000000000000000', # 21 digits
+    ].each do |literal|
+      doc = "#{literal} "
+      parser = new_parser
+      value = nil
+      doc.each_char do |char|
+        parser << char
+        value = parser.value if parser.parse
+      end
+      assert_equal Integer(literal, 10), value, doc.inspect
+    end
+  end
+
   def test_nul_byte_is_a_syntax_error
     # A NUL byte in a structural position must raise, not stall forever waiting for more input
     # (peek() returns 0 both at EOS and for a literal NUL byte).


### PR DESCRIPTION
This PR widens the range of `uint64_t` and `int64_t`'s that are returned via the fast path in `json_decode_integer` rather than falling through to `json_decode_large_integer`.

## Benchmarks

Run on a M1 Macbook Air.  Benchmarked against `master` as of commit `5a32e4367ca5976f62af12887a09685b7109b054`.

Most of the values in `integers.json` are 19 or 20 digits in length.

```
== Parsing integer parsing (204025 bytes)
ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   224.000 i/100ms
Calculating -------------------------------------
               after      2.446k (± 0.5%) i/s  (408.81 μs/i) -     12.320k in   5.036521s

Comparison:
before:     1200.8 i/s
 after:     2446.1 i/s - 2.04x  faster
```